### PR TITLE
Fix semantic scholar api key requirements and bug in LLM calling in `perform_ideation_temp_free.py`

### DIFF
--- a/ai_scientist/perform_ideation_temp_free.py
+++ b/ai_scientist/perform_ideation_temp_free.py
@@ -169,7 +169,7 @@ def generate_temp_free_idea(
                     )
 
                 response_text, msg_history = get_response_from_llm(
-                    msg=prompt_text,
+                    prompt=prompt_text,
                     client=client,
                     model=model,
                     system_message=system_prompt,


### PR DESCRIPTION
In this PR, I fixed two bugs in using `perform_ideation_temp_free.py`, namely:
1. The semantic scholar component now forces the existence of the API key in the environment variables. When API key is not set, an error is thrown, which is not necessary. I removed this requirement in `tools/semantic_scholar.py`.
2. The `get_response_from_llm` function should expect the parameter to be `prompt` but not `msg`. This is a simple fix.