### PR TITLE
added 'idea' keyword explicitly in system prompt for robustness

### DIFF
--- a/ai_scientist/perform_ideation_temp_free.py
+++ b/ai_scientist/perform_ideation_temp_free.py
@@ -78,7 +78,7 @@ If you choose to finalize your idea, provide the IDEA JSON in the arguments:
 
 IDEA JSON:
 ```json
-{{
+"idea": {{
     "Name": "...",
     "Title": "...",
     "Short Hypothesis": "...",


### PR DESCRIPTION
As explained in my previous pull request, I found that explicitly adding the keyword "idea" in the IDEA JSON template significantly improves robustness for Gemini models. Previously, these models omitted the keyword "idea" more than half the time, causing JSON parsing failures. By simply including this keyword in the template, Gemini models now correctly output it approximately 80% of the time while not affecting already supported models like gpt-4o.