### PR TITLE
added example env file + code + python-dotenv to load the env on init

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+export OPENAI_API_KEY="YOUR_OPENAI_KEY_HERE"
+# export S2_API_KEY="YOUR_S2_KEY_HERE"
+# Set AWS credentials if using Bedrock
+# export AWS_ACCESS_KEY_ID="YOUR_AWS_ACCESS_KEY_ID"
+# export AWS_SECRET_ACCESS_KEY="YOUR_AWS_SECRET_KEY"
+# export AWS_REGION_NAME="your-aws-region"

--- a/ai_scientist/llm.py
+++ b/ai_scientist/llm.py
@@ -8,6 +8,15 @@ import anthropic
 import backoff
 import openai
 
+from dotenv import load_dotenv
+import os
+
+# Load environment variables from .env file
+load_dotenv()
+
+# Verify the API key is loaded
+assert os.getenv("OPENAI_API_KEY"), "OPENAI_API_KEY is not set!"
+
 MAX_NUM_TOKENS = 4096
 
 AVAILABLE_LLMS = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ jsonschema
 omegaconf
 botocore
 boto3
+python-dotenv


### PR DESCRIPTION
Hi I added example .env file and python-dotenv to make getting started with it as easy as creating/editing a single file + running the command to load the dotenv.

Scenarios
If the .env file is present:

python-dotenv will load the variables from the file into the Python runtime.
If a variable is already set in the terminal (e.g., via export), it will take precedence over the .env file.
If the .env file is absent:

The application will rely on the environment variables already set in the terminal (e.g., via export).

python-dotenv will not affect these variables.

Impact on Others
For users who export variables manually: They can continue doing so without any issues. The presence of python-dotenv in requirements.txt will not override or interfere with their manually set environment variables.
For users relying on .env files: The python-dotenv package ensures that variables in the .env file are loaded automatically, making it easier for them to manage environment variables.