### PR TITLE
Support Apple Silicon

### DIFF
--- a/MACOS_SETUP.md
+++ b/MACOS_SETUP.md
@@ -1,0 +1,53 @@
+# Running AI Scientist-v2 on Apple Silicon
+
+The original AI Scientist-v2 codebase is optimized for Linux and NVIDIA GPUs (CUDA). However, you can run it on macOS with Apple Silicon by adapting the installation steps and configuration.
+
+## 1. Prerequisites
+
+### Miniforge (Conda)
+
+You will need Miniforge, the community-driven distribution of Conda optimized for Apple Silicon.
+
+```bash
+curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh"
+bash Miniforge3-MacOSX-arm64.sh
+source ~/miniforge3/bin/activate
+```
+
+## 2. Installation
+
+### Step 1: Set up Python Environment
+
+The project requires **Python 3.11**.
+
+```bash
+conda create -n ai_scientist python=3.11
+conda activate ai_scientist
+```
+
+### Step 2: Install System Tools
+
+You need `poppler` (for PDF processing) and `chktex` (for LaTeX linting).
+
+```bash
+conda install -c conda-forge poppler chktex
+```
+
+### Step 3: Install Python Dependencies
+
+```bash
+pip install torch torchvision torchaudio
+pip install -r requirements.txt
+```
+
+## 3. Configuration & API Keys
+
+See [Supported Models and API Keys](README.md#supported-models-and-api-keys) in the main README for detailed information on configuring API keys for OpenAI, Gemini, Claude (AWS Bedrock), and Semantic Scholar.
+
+## 4. Running Experiments
+
+Once installation is complete, follow the [Generate Research Ideas](README.md#generate-research-ideas) and [Run AI Scientist-v2 Paper Generation Experiments](README.md#run-ai-scientist-v2-paper-generation-experiments) sections in the main README.
+
+## 5. Troubleshooting
+
+- **"Torch not compiled with CUDA enabled"**: This means a script is explicitly trying to use `cuda`. The patched `parallel_agent.py` should prevent this, but if it happens, check the generated code in `experiments/`.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ This system autonomously generates hypotheses, runs experiments, analyzes data, 
 
 This code is designed to run on Linux with NVIDIA GPUs using CUDA and PyTorch.
 
+To run on macOS with Apple Silicon, see [MACOS_SETUP.md](MACOS_SETUP.md) for installation instructions.
+
 ### Installation
 
 ```bash

--- a/ai_scientist/ideas/i_cant_believe_its_not_better.py
+++ b/ai_scientist/ideas/i_cant_believe_its_not_better.py
@@ -84,7 +84,7 @@ device = torch.device(
     "cuda"
     if torch.cuda.is_available()
     else "mps"
-    if torch.backends.mps.is_available()
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
     else "cpu"
 )
 pipe = pipeline(
@@ -231,7 +231,7 @@ model = model.to(device)
 
 start_time = time.time()
 # Use torch.compile with safer settings
-if torch.cuda.is_available() or torch.backends.mps.is_available():
+if torch.cuda.is_available() or (hasattr(torch.backends, "mps") and torch.backends.mps.is_available() and hasattr(torch, "compile")):
     try:
         model = torch.compile(model)
     except Exception as e:

--- a/ai_scientist/ideas/i_cant_believe_its_not_better.py
+++ b/ai_scientist/ideas/i_cant_believe_its_not_better.py
@@ -80,7 +80,13 @@ from PIL import Image
 import requests
 
 # Set device to GPU if available
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = torch.device(
+    "cuda"
+    if torch.cuda.is_available()
+    else "mps"
+    if torch.backends.mps.is_available()
+    else "cpu"
+)
 pipe = pipeline(
     task="image-feature-extraction",
     model="google/vit-base-patch16-384",
@@ -225,7 +231,7 @@ model = model.to(device)
 
 start_time = time.time()
 # Use torch.compile with safer settings
-if torch.cuda.is_available():
+if torch.cuda.is_available() or torch.backends.mps.is_available():
     try:
         model = torch.compile(model)
     except Exception as e:

--- a/ai_scientist/ideas/i_cant_believe_its_not_betterrealworld.py
+++ b/ai_scientist/ideas/i_cant_believe_its_not_betterrealworld.py
@@ -48,7 +48,13 @@ from PIL import Image
 import requests
 
 # Set device to GPU if available
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = torch.device(
+    "cuda"
+    if torch.cuda.is_available()
+    else "mps"
+    if torch.backends.mps.is_available()
+    else "cpu"
+)
 pipe = pipeline(
     task="image-feature-extraction",
     model="google/vit-base-patch16-384",
@@ -193,7 +199,7 @@ model = model.to(device)
 
 start_time = time.time()
 # Use torch.compile with safer settings
-if torch.cuda.is_available():
+if torch.cuda.is_available() or torch.backends.mps.is_available():
     try:
         model = torch.compile(model)
     except Exception as e:

--- a/ai_scientist/ideas/i_cant_believe_its_not_betterrealworld.py
+++ b/ai_scientist/ideas/i_cant_believe_its_not_betterrealworld.py
@@ -52,7 +52,7 @@ device = torch.device(
     "cuda"
     if torch.cuda.is_available()
     else "mps"
-    if torch.backends.mps.is_available()
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
     else "cpu"
 )
 pipe = pipeline(
@@ -199,7 +199,7 @@ model = model.to(device)
 
 start_time = time.time()
 # Use torch.compile with safer settings
-if torch.cuda.is_available() or torch.backends.mps.is_available():
+if torch.cuda.is_available() or (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()):
     try:
         model = torch.compile(model)
     except Exception as e:

--- a/ai_scientist/treesearch/parallel_agent.py
+++ b/ai_scientist/treesearch/parallel_agent.py
@@ -1148,10 +1148,11 @@ def get_gpu_count() -> int:
             import torch
             if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
                 return 1  # MPS presents as a single device
-        except Exception:
-            pass
-
-        return 0
+        except ImportError:
+            return 0
+        except Exception as exc:
+            logger.debug("Error while checking for Apple Silicon MPS support: %s", exc)
+            return 0
 
 
 class ParallelAgent:

--- a/ai_scientist/treesearch/parallel_agent.py
+++ b/ai_scientist/treesearch/parallel_agent.py
@@ -298,9 +298,14 @@ class MinimalAgent:
     def _prompt_impl_guideline(self):
         impl_guideline = [
             "CRITICAL GPU REQUIREMENTS - Your code MUST include ALL of these:",
-            "  - At the start of your code, add these lines to handle GPU/CPU:",
+            "  - At the start of your code, add these lines to handle GPU/CPU/MPS:",
             "    ```python",
-            "    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')",
+            "    if torch.cuda.is_available():",
+            "        device = torch.device('cuda')",
+            "    elif torch.backends.mps.is_available():",
+            "        device = torch.device('mps')",
+            "    else:",
+            "        device = torch.device('cpu')",
             "    print(f'Using device: {device}')",
             "    ```",
             "  - ALWAYS move models to device using the `.to(device)` method",
@@ -1118,9 +1123,9 @@ class GPUManager:
 
 
 def get_gpu_count() -> int:
-    """Get number of available NVIDIA GPUs without using torch"""
+    """Get number of available GPUs (NVIDIA CUDA or Apple Silicon MPS)"""
     try:
-        # First try using nvidia-smi
+        # First try using nvidia-smi for NVIDIA GPUs
         nvidia_smi = subprocess.run(
             ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv,noheader"],
             capture_output=True,
@@ -1135,8 +1140,54 @@ def get_gpu_count() -> int:
         if cuda_visible_devices:
             # Filter out empty strings and -1 values
             devices = [d for d in cuda_visible_devices.split(",") if d and d != "-1"]
-            return len(devices)
+            if len(devices) > 0:
+                return len(devices)
+
+        # Check for Apple Silicon MPS
+        try:
+            import torch
+
+            if torch.backends.mps.is_available():
+                return 1  # MPS presents as a single device
+        except ImportError:
+            pass
+
         return 0
+
+
+def get_device_type() -> str:
+    """Get the type of compute device available (cuda, mps, or cpu)"""
+    try:
+        # First try using nvidia-smi for NVIDIA GPUs
+        nvidia_smi = subprocess.run(
+            ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        gpus = nvidia_smi.stdout.strip().split("\n")
+        if len(gpus) > 0:
+            return "cuda"
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    # Check environment variable for CUDA
+    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if cuda_visible_devices:
+        devices = [d for d in cuda_visible_devices.split(",") if d and d != "-1"]
+        if len(devices) > 0:
+            return "cuda"
+
+    # Check for Apple Silicon MPS
+    try:
+        import torch
+
+        if torch.backends.mps.is_available():
+            return "mps"
+    except ImportError:
+        pass
+
+    return "cpu"
 
 
 class ParallelAgent:
@@ -1167,11 +1218,14 @@ class ParallelAgent:
         self.data_preview = None
         self.num_workers = cfg.agent.num_workers
         self.num_gpus = get_gpu_count()
+        self.device_type = get_device_type()
         print(f"num_gpus: {self.num_gpus}")
         if self.num_gpus == 0:
             print("No GPUs detected, falling back to CPU-only mode")
+        elif self.device_type == "mps":
+            print(f"Detected Apple Silicon MPS device")
         else:
-            print(f"Detected {self.num_gpus} GPUs")
+            print(f"Detected {self.num_gpus} CUDA GPUs")
 
         self.gpu_manager = GPUManager(self.num_gpus) if self.num_gpus > 0 else None
 
@@ -1283,7 +1337,7 @@ class ParallelAgent:
 
             # Add seed to node code
             node_data["code"] = (
-                f"# Set random seed\nimport random\nimport numpy as np\nimport torch\n\nseed = {seed}\nrandom.seed(seed)\nnp.random.seed(seed)\ntorch.manual_seed(seed)\nif torch.cuda.is_available():\n    torch.cuda.manual_seed(seed)\n\n"
+                f"# Set random seed\nimport random\nimport numpy as np\nimport torch\n\nseed = {seed}\nrandom.seed(seed)\nnp.random.seed(seed)\ntorch.manual_seed(seed)\nif torch.cuda.is_available():\n    torch.cuda.manual_seed(seed)\nelif torch.backends.mps.is_available():\n    torch.mps.manual_seed(seed)\n\n"
                 + node_code
             )
 

--- a/ai_scientist/treesearch/parallel_agent.py
+++ b/ai_scientist/treesearch/parallel_agent.py
@@ -302,7 +302,7 @@ class MinimalAgent:
             "    ```python",
             "    if torch.cuda.is_available():",
             "        device = torch.device('cuda')",
-            "    elif torch.backends.mps.is_available():",
+            "    elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():",
             "        device = torch.device('mps')",
             "    else:",
             "        device = torch.device('cpu')",
@@ -1146,7 +1146,7 @@ def get_gpu_count() -> int:
         # Check for Apple Silicon MPS with torch
         try:
             import torch
-            if torch.backends.mps.is_available():
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
                 return 1  # MPS presents as a single device
         except Exception:
             pass
@@ -1298,7 +1298,7 @@ class ParallelAgent:
 
             # Add seed to node code
             node_data["code"] = (
-                f"# Set random seed\nimport random\nimport numpy as np\nimport torch\n\nseed = {seed}\nrandom.seed(seed)\nnp.random.seed(seed)\ntorch.manual_seed(seed)\nif torch.cuda.is_available():\n    torch.cuda.manual_seed(seed)\nelif torch.backends.mps.is_available():\n    torch.mps.manual_seed(seed)\n\n"
+                f"# Set random seed\nimport random\nimport numpy as np\nimport torch\n\nseed = {seed}\nrandom.seed(seed)\nnp.random.seed(seed)\ntorch.manual_seed(seed)\nif torch.cuda.is_available():\n    torch.cuda.manual_seed(seed)\nelif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():\n    torch.mps.manual_seed(seed)\n\n"
                 + node_code
             )
 

--- a/ai_scientist/treesearch/parallel_agent.py
+++ b/ai_scientist/treesearch/parallel_agent.py
@@ -1123,7 +1123,7 @@ class GPUManager:
 
 
 def get_gpu_count() -> int:
-    """Get number of available GPUs (NVIDIA CUDA or Apple Silicon MPS)"""
+    """Get number of available GPUs (NVIDIA CUDA without torch or Apple Silicon MPS with torch)"""
     try:
         # First try using nvidia-smi for NVIDIA GPUs
         nvidia_smi = subprocess.run(
@@ -1143,51 +1143,15 @@ def get_gpu_count() -> int:
             if len(devices) > 0:
                 return len(devices)
 
-        # Check for Apple Silicon MPS
+        # Check for Apple Silicon MPS with torch
         try:
             import torch
-
             if torch.backends.mps.is_available():
                 return 1  # MPS presents as a single device
-        except ImportError:
+        except Exception:
             pass
 
         return 0
-
-
-def get_device_type() -> str:
-    """Get the type of compute device available (cuda, mps, or cpu)"""
-    try:
-        # First try using nvidia-smi for NVIDIA GPUs
-        nvidia_smi = subprocess.run(
-            ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv,noheader"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        gpus = nvidia_smi.stdout.strip().split("\n")
-        if len(gpus) > 0:
-            return "cuda"
-    except (subprocess.SubprocessError, FileNotFoundError):
-        pass
-
-    # Check environment variable for CUDA
-    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
-    if cuda_visible_devices:
-        devices = [d for d in cuda_visible_devices.split(",") if d and d != "-1"]
-        if len(devices) > 0:
-            return "cuda"
-
-    # Check for Apple Silicon MPS
-    try:
-        import torch
-
-        if torch.backends.mps.is_available():
-            return "mps"
-    except ImportError:
-        pass
-
-    return "cpu"
 
 
 class ParallelAgent:
@@ -1218,14 +1182,11 @@ class ParallelAgent:
         self.data_preview = None
         self.num_workers = cfg.agent.num_workers
         self.num_gpus = get_gpu_count()
-        self.device_type = get_device_type()
         print(f"num_gpus: {self.num_gpus}")
         if self.num_gpus == 0:
             print("No GPUs detected, falling back to CPU-only mode")
-        elif self.device_type == "mps":
-            print(f"Detected Apple Silicon MPS device")
         else:
-            print(f"Detected {self.num_gpus} CUDA GPUs")
+            print(f"Detected {self.num_gpus} GPUs")
 
         self.gpu_manager = GPUManager(self.num_gpus) if self.num_gpus > 0 else None
 

--- a/launch_scientist_bfts.py
+++ b/launch_scientist_bfts.py
@@ -137,7 +137,7 @@ def get_available_gpus(gpu_ids=None):
 
     if torch.cuda.is_available():
         return list(range(torch.cuda.device_count()))
-    elif torch.backends.mps.is_available():
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
         return [0]
     else:
         return []

--- a/launch_scientist_bfts.py
+++ b/launch_scientist_bfts.py
@@ -134,7 +134,13 @@ def parse_arguments():
 def get_available_gpus(gpu_ids=None):
     if gpu_ids is not None:
         return [int(gpu_id) for gpu_id in gpu_ids.split(",")]
-    return list(range(torch.cuda.device_count()))
+
+    if torch.cuda.is_available():
+        return list(range(torch.cuda.device_count()))
+    elif torch.backends.mps.is_available():
+        return [0]
+    else:
+        return []
 
 
 def find_pdf_path_for_review(idea_dir):


### PR DESCRIPTION
## Problem

The project didn’t support running on macOS Apple Silicon (MPS).

## Approach

- Added a macOS Apple Silicon setup guide (`MACOS_SETUP.md`) and linked it from the `README.md`.
- Updated GPU detection / GPU worker selection to recognize MPS in addition to CUDA, while keeping the existing CUDA path as-is as much as possible (and only adding a safe MPS check on the non-CUDA/CPU path).
- Updated the agent’s device-selection guidance and seed-setting snippet to handle MPS.
- Updated the `i_cant_believe_its_not_better*` examples to select `cuda` → `mps` → `cpu`, and guarded `torch.compile` / MPS checks for compatibility.

## Limitations

- MPS is treated as a single device, and multi-device scheduling is still CUDA-oriented.
- This improves defaults and common entrypoints, but LLM-generated experiment code can still explicitly reference `cuda`.
- No tests are added for macOS/MPS behavior.