### PR TITLE
Add Claude Code skills for orchestrating the AI Scientist v2 pipeline

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "strelkon-AI-Scientist-v2",
+  "owner": {
+    "name": "strelkon"
+  },
+  "plugins": [
+    {
+      "name": "ai-scientist",
+      "description": "Autonomous scientific research pipeline — generate ideas, run experiments, write papers, and peer review. No external LLM API keys required.",
+      "source": "./plugin"
+    }
+  ]
+}

--- a/.claude/skills/ai-scientist-experiment/SKILL.md
+++ b/.claude/skills/ai-scientist-experiment/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: ai-scientist-experiment
+description: Run AI Scientist v2 best-first tree search experiments on a research idea (without writeup or review)
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+argument-hint: <ideas-json-path> [--idea_idx N] [--load_code] [--add_dataset_ref]
+---
+
+# AI Scientist v2 — Experiment Execution Only
+
+You are running just the experiment stage of AI Scientist v2. This performs best-first tree search (BFTS) to explore and validate a research idea through code generation, execution, and evaluation.
+
+## Prerequisites
+
+1. **API keys** — Required for the models specified in `bfts_config.yaml` (Anthropic Bedrock for coding, OpenAI for feedback by default).
+2. **GPU** — CUDA-capable GPU required.
+3. **Ideas file** — Pre-generated ideas JSON (from `/ai-scientist-ideate`).
+
+## Usage
+
+Parse `$ARGUMENTS`:
+
+- **Positional arg 1** (`$0`): Path to ideas JSON file (required)
+- `--idea_idx N`: Which idea to run (default: 0)
+- `--load_code`: Also load the companion `.py` starter code file
+- `--add_dataset_ref`: Include HuggingFace dataset reference code
+- `--model_agg_plots MODEL`: Model for plot aggregation (default: o3-mini-2025-01-31)
+
+## Execution
+
+```bash
+cd /home/user/AI-Scientist-v2
+
+export AI_SCIENTIST_ROOT=/home/user/AI-Scientist-v2
+
+python launch_scientist_bfts.py \
+  --load_ideas "$0" \
+  --skip_writeup \
+  --skip_review \
+  [other flags from $ARGUMENTS]
+```
+
+**This is a long-running process** (typically 2-6 hours depending on config). Run with `run_in_background: true`.
+
+## Configuration
+
+The experiment is controlled by `bfts_config.yaml`. Key settings:
+- `agent.num_workers`: Parallel exploration paths (default: 4)
+- `agent.stages.stage{1-4}_max_iters`: Iterations per stage
+- `agent.code.model`: LLM for code generation
+- `agent.feedback.model`: LLM for evaluating results
+- `exec.timeout`: Per-execution timeout in seconds
+
+The 4 experiment stages:
+1. **Initial Implementation** — Baseline methods
+2. **Baseline Tuning** — Optimization and tuning
+3. **Creative Research** — Novel algorithmic improvements
+4. **Ablation Studies** — Component analysis
+
+## Output
+
+Results in `experiments/{timestamp}_{idea_name}_attempt_{id}/`:
+- `logs/` — Full experiment logs
+- `logs/tree_plot.html` — Interactive tree visualization
+- `figures/` — Aggregated plots
+- `token_tracker.json` — API cost tracking
+
+After completion, summarize key metrics and findings from the experiment logs.

--- a/.claude/skills/ai-scientist-experiment/SKILL.md
+++ b/.claude/skills/ai-scientist-experiment/SKILL.md
@@ -1,83 +1,363 @@
 ---
 name: ai-scientist-experiment
-description: Run AI Scientist v2 best-first tree search experiments — requires API keys for parallel LLM code generation
+description: Run AI Scientist v2 experiments using Claude Code as the code generator — no external API keys required. Implements the 4-stage BFTS workflow natively.
 disable-model-invocation: true
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent
 argument-hint: <ideas-json-path> [--idea_idx N] [--load_code] [--add_dataset_ref]
+effort: max
 ---
 
-# AI Scientist v2 — Experiment Execution
+# AI Scientist v2 — Experiment Execution (Claude Code Native)
 
-Run the best-first tree search (BFTS) experiments. **This stage requires API keys** because it performs parallel LLM-driven code generation and execution that cannot be replicated within a single Claude Code session.
-
-## Prerequisites
-
-1. **API keys** — Required for models in `bfts_config.yaml`:
-   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME` for Bedrock (default coding model)
-   - `OPENAI_API_KEY` for feedback model (GPT-4o)
-2. **GPU** — CUDA-capable GPU required for experiment execution
-3. **Ideas file** — Pre-generated ideas JSON (from `/ai-scientist-ideate`)
-4. **Dependencies** — `pip install -r requirements.txt` must have been run
-
-## Verify Environment
-
-Before running, check:
-
-```bash
-python -c "import torch; print(f'CUDA available: {torch.cuda.is_available()}, GPUs: {torch.cuda.device_count()}')"
-echo "OPENAI_API_KEY set: ${OPENAI_API_KEY:+yes}"
-echo "AWS_ACCESS_KEY_ID set: ${AWS_ACCESS_KEY_ID:+yes}"
-```
-
-If keys are missing, inform the user which are needed and stop.
+You are an expert ML researcher running experiments through a structured 4-stage process. You will generate Python code, execute it, analyze results, debug failures, and iteratively improve — all within Claude Code. **No external API keys required.**
 
 ## Arguments
 
 - **Positional arg 1** (`$ARGUMENTS` first word): Path to ideas JSON file (required)
 - `--idea_idx N`: Which idea to run (default: 0)
-- `--load_code`: Also load the companion `.py` starter code file
+- `--load_code`: Load companion `.py` starter code file
 - `--add_dataset_ref`: Include HuggingFace dataset reference code
-- `--model_agg_plots MODEL`: Model for plot aggregation (default: o3-mini-2025-01-31)
 
-## Execution
+## Step 1: Setup
+
+### 1a. Load the Research Idea
 
 ```bash
 cd /home/user/AI-Scientist-v2
-export AI_SCIENTIST_ROOT=/home/user/AI-Scientist-v2
-
-python launch_scientist_bfts.py \
-  --load_ideas "$IDEAS_PATH" \
-  --idea_idx ${IDEA_IDX:-0} \
-  --skip_writeup \
-  --skip_review \
-  ${LOAD_CODE:+--load_code} \
-  ${ADD_DATASET_REF:+--add_dataset_ref} \
-  --model_agg_plots "${MODEL_AGG_PLOTS:-o3-mini-2025-01-31}"
 ```
 
-**This is a long-running process** (typically 2-6 hours). Run it with `run_in_background: true` on the Bash tool.
+Read the ideas JSON file and extract the idea at the specified index. Read the idea's fields:
+- **Name**, **Title**, **Short Hypothesis**
+- **Abstract**, **Experiments** (specific experiment plans)
+- **Code** (if `--load_code` was used and code exists)
 
-## Configuration
+### 1b. Create Experiment Directory
 
-The experiment is controlled by `bfts_config.yaml` in the project root. Key settings:
-- `agent.num_workers`: Parallel exploration paths (default: 4)
-- `agent.stages.stage{1-4}_max_iters`: Max iterations per stage (20, 12, 12, 18)
-- `agent.code.model`: LLM for code generation (default: Claude 3.5 Sonnet via Bedrock)
-- `agent.feedback.model`: LLM for evaluating results (default: GPT-4o)
-- `exec.timeout`: Per-execution timeout in seconds (default: 3600)
-
-## Output
-
-Results in `experiments/{timestamp}_{idea_name}_attempt_{id}/`:
-- `idea.md` / `idea.json` — The research idea
-- `logs/` — Full experiment logs and tree visualization
-- `logs/0-run/baseline_summary.json` — Baseline stage results
-- `logs/0-run/research_summary.json` — Research stage results
-- `logs/0-run/ablation_summary.json` — Ablation stage results
-- `figures/` — Aggregated plots
-- `token_tracker.json` — API cost tracking
-
-After completion, tell the user they can generate a paper with:
+```bash
+DATE=$(date +%Y-%m-%d_%H-%M-%S)
+IDEA_NAME="<idea Name field>"
+EXPERIMENT_DIR="experiments/${DATE}_${IDEA_NAME}_attempt_0"
+mkdir -p "$EXPERIMENT_DIR/logs/0-run"
+mkdir -p "$EXPERIMENT_DIR/figures"
 ```
-/ai-scientist-writeup experiments/<dir>/
+
+Save the idea as `idea.md` and `idea.json` in the experiment directory.
+
+### 1c. Define Evaluation Metrics
+
+Based on the research idea and experiments described, define ONE primary evaluation metric:
+- **metric_name**: Precise name (e.g., "validation accuracy", "test BLEU score")
+- **lower_is_better**: Whether lower values are better (true for loss, false for accuracy)
+- **description**: What this metric measures
+
+Validation loss is always tracked separately in addition to the primary metric.
+
+## Step 2: Stage 1 — Initial Implementation
+
+**Goal**: Get a basic working implementation of the research idea.
+
+### Code Generation Requirements
+
+All generated experiment code MUST follow these conventions:
+
+```python
+import os
+import numpy as np
+import torch
+
+# GPU setup
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+print(f'Using device: {device}')
+
+# Working directory
+working_dir = os.path.join(os.getcwd(), 'working')
+os.makedirs(working_dir, exist_ok=True)
+
+# ... experiment code ...
+
+# Save results in standard format
+experiment_data = {
+    'dataset_name_1': {
+        'metrics': {'train': [epoch1_val, epoch2_val, ...], 'val': [...]},
+        'losses': {'train': [...], 'val': [...]},
+        'predictions': [...],  # optional
+        'ground_truth': [...]  # optional
+    }
+}
+np.save(os.path.join(working_dir, 'experiment_data.npy'), experiment_data)
+print(f'Results saved to {os.path.join(working_dir, "experiment_data.npy")}')
 ```
+
+**Rules:**
+- ALL code at global scope — NO `if __name__ == "__main__"` blocks
+- Move models and data to `device` using `.to(device)`
+- Use try-except for robustness
+- Print metrics clearly: `print(f'Dataset: {name}, {metric}: {value:.4f}')`
+- Keep execution under 60 minutes
+- Start with ONE simple dataset, use standard HuggingFace datasets when possible
+
+### Iteration Loop (up to 5 attempts)
+
+For each attempt:
+
+1. **Generate code**: Write a complete Python script implementing the baseline approach described in the idea
+2. **Save and execute**:
+   ```bash
+   cd $EXPERIMENT_DIR
+   mkdir -p workspace/working
+   # Write the code to workspace/runfile.py using the Write tool
+   cd workspace && timeout 3600 python runfile.py 2>&1 | tee execution_output.txt
+   ```
+3. **Analyze results**:
+   - Check if `workspace/working/experiment_data.npy` was created
+   - Read execution output for errors or metrics
+   - If the code errored: **debug** — analyze the error, fix the code, retry
+   - If the code succeeded: **evaluate** — check if metrics are reasonable
+4. **If successful**: Move to plotting, then Stage 2
+5. **If failed after 5 attempts**: Report failure and stop
+
+### Generate Plots
+
+After a successful run, generate a plotting script:
+
+```python
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import os
+
+working_dir = os.path.join(os.getcwd(), 'working')
+data = np.load(os.path.join(working_dir, 'experiment_data.npy'), allow_pickle=True).item()
+
+figures_dir = os.path.join(os.getcwd(), '..', 'figures')
+os.makedirs(figures_dir, exist_ok=True)
+
+# Generate plots for each dataset
+for dataset_name, dataset_data in data.items():
+    try:
+        # Training curves
+        if 'losses' in dataset_data:
+            fig, ax = plt.subplots(figsize=(8, 6))
+            # ... plot training/validation loss curves
+            plt.savefig(os.path.join(figures_dir, f'{dataset_name}_training_curves.png'), dpi=300, bbox_inches='tight')
+            plt.close()
+
+        # Metrics over epochs
+        if 'metrics' in dataset_data:
+            fig, ax = plt.subplots(figsize=(8, 6))
+            # ... plot metric curves
+            plt.savefig(os.path.join(figures_dir, f'{dataset_name}_metrics.png'), dpi=300, bbox_inches='tight')
+            plt.close()
+    except Exception as e:
+        print(f'Error plotting {dataset_name}: {e}')
+```
+
+Execute the plotting script. Then **view the generated plots** using the Read tool to verify they look correct.
+
+### Save Stage 1 Summary
+
+After Stage 1, save a summary to `$EXPERIMENT_DIR/logs/0-run/baseline_summary.json`:
+
+```json
+{
+  "best_node": {
+    "overall_plan": "<description of approach>",
+    "analysis": "<analysis of results>",
+    "metric": "<primary metric value>",
+    "code": "<the working Python code>",
+    "plot_code": "<the plotting code>",
+    "plot_analyses": ["<description of each plot>"],
+    "vlm_feedback_summary": "<summary of what plots show>",
+    "exp_results_npy_files": ["experiment_results/stage1/experiment_data.npy"],
+    "datasets_successfully_tested": ["dataset_name_1"]
+  }
+}
+```
+
+Copy experiment data:
+```bash
+mkdir -p $EXPERIMENT_DIR/logs/0-run/experiment_results/stage1
+cp $EXPERIMENT_DIR/workspace/working/experiment_data.npy $EXPERIMENT_DIR/logs/0-run/experiment_results/stage1/
+```
+
+## Step 3: Stage 2 — Baseline Tuning
+
+**Goal**: Optimize hyperparameters of the Stage 1 implementation. DO NOT change model architecture. Introduce ONE additional dataset (total: 2 datasets).
+
+### Iteration Loop (up to 4 attempts)
+
+For each attempt, pick ONE hyperparameter to tune:
+1. Training longer (more epochs)
+2. Learning rate adjustment
+3. Batch size optimization
+4. Regularization (dropout, weight decay)
+5. Other algorithm-specific parameters
+
+For each:
+1. Take the best Stage 1 code as base
+2. Modify the specific hyperparameter
+3. Add a second dataset
+4. Execute and analyze results
+5. Compare metrics with Stage 1 baseline
+6. View generated plots to assess convergence
+
+### Save Stage 2 Summary
+
+Save to `$EXPERIMENT_DIR/logs/0-run/baseline_summary.json` (update the existing file to include tuning results):
+
+Include:
+- Which hyperparameters were tuned
+- Results for each configuration
+- Best configuration found
+- Comparison with Stage 1 baseline
+
+Copy results:
+```bash
+mkdir -p $EXPERIMENT_DIR/logs/0-run/experiment_results/stage2
+cp $EXPERIMENT_DIR/workspace/working/experiment_data.npy $EXPERIMENT_DIR/logs/0-run/experiment_results/stage2/
+```
+
+## Step 4: Stage 3 — Creative Research
+
+**Goal**: Explore novel improvements to the approach. Be creative. Use THREE HuggingFace datasets total.
+
+### Iteration Loop (up to 4 attempts)
+
+For each attempt:
+1. Start from the best Stage 2 code
+2. Propose a **novel improvement** inspired by the research idea:
+   - New loss functions or regularization techniques
+   - Architectural modifications
+   - Data augmentation strategies
+   - Ensemble methods
+   - Novel training procedures
+3. Add a third dataset
+4. Execute and compare with previous stages
+5. View plots to verify improvements
+
+### Save Stage 3 Summary
+
+Save to `$EXPERIMENT_DIR/logs/0-run/research_summary.json`:
+
+```json
+{
+  "best_node": {
+    "overall_plan": "<description of novel approach>",
+    "analysis": "<analysis comparing to baseline>",
+    "metric": "<primary metric value>",
+    "code": "<the working Python code>",
+    "plot_code": "<plotting code>",
+    "plot_analyses": ["<description of each plot>"],
+    "vlm_feedback_summary": "<summary of improvements>",
+    "exp_results_npy_files": ["experiment_results/stage3/experiment_data.npy"],
+    "datasets_successfully_tested": ["dataset1", "dataset2", "dataset3"]
+  }
+}
+```
+
+Copy results:
+```bash
+mkdir -p $EXPERIMENT_DIR/logs/0-run/experiment_results/stage3
+cp $EXPERIMENT_DIR/workspace/working/experiment_data.npy $EXPERIMENT_DIR/logs/0-run/experiment_results/stage3/
+```
+
+## Step 5: Stage 4 — Ablation Studies
+
+**Goal**: Conduct systematic component analysis. Use the same datasets from Stage 3.
+
+### Iteration Loop (3-5 ablations)
+
+For each ablation:
+1. Start from the best Stage 3 code
+2. **Remove or disable ONE specific component** to measure its contribution:
+   - Remove the novel technique from Stage 3 (baseline comparison)
+   - Disable data augmentation
+   - Simplify the architecture
+   - Remove regularization
+   - Use different loss function
+3. Execute with the same 3 datasets
+4. Compare with full Stage 3 model
+5. Record the performance delta
+
+### Save Stage 4 Summary
+
+Save to `$EXPERIMENT_DIR/logs/0-run/ablation_summary.json`:
+
+```json
+{
+  "ablation_1_name": {
+    "overall_plan": "<what was ablated>",
+    "ablation_name": "<component removed>",
+    "analysis": "<impact analysis>",
+    "metric": "<metric values>",
+    "code": "<ablation code>",
+    "exp_results_npy_files": ["experiment_results/stage4_ablation1/experiment_data.npy"],
+    "datasets_successfully_tested": ["dataset1", "dataset2", "dataset3"]
+  },
+  "ablation_2_name": { ... }
+}
+```
+
+Copy results:
+```bash
+mkdir -p $EXPERIMENT_DIR/logs/0-run/experiment_results/stage4_ablation1
+cp $EXPERIMENT_DIR/workspace/working/experiment_data.npy $EXPERIMENT_DIR/logs/0-run/experiment_results/stage4_ablation1/
+# Repeat for each ablation
+```
+
+## Step 6: Plot Aggregation
+
+After all stages, create a comprehensive plot aggregation script that:
+
+1. Loads ALL `.npy` files from all stages
+2. Creates publication-ready comparison plots:
+   - **Cross-stage comparison**: Bar chart of primary metric across stages
+   - **Training curves**: Overlaid loss/metric curves for all configurations
+   - **Per-dataset comparison**: Performance across datasets
+   - **Ablation chart**: Bar chart showing component contributions
+3. Saves up to 12 figures in `$EXPERIMENT_DIR/figures/`
+
+Guidelines:
+- DPI: 300
+- Remove top/right spines
+- Clear labels (no underscores, use spaces)
+- Legends always visible
+- Each plot in its own try-except block
+- Combine related plots into subplots (up to 3 per figure)
+
+Save the aggregation script as `$EXPERIMENT_DIR/auto_plot_aggregator.py`.
+
+View all generated plots with the Read tool to verify quality.
+
+## Step 7: Save Research Idea Markdown
+
+Create `$EXPERIMENT_DIR/research_idea.md` that is a copy of `$EXPERIMENT_DIR/idea.md`.
+
+## Step 8: Report Results
+
+Summarize for the user:
+
+1. **Stage 1 Results**: Baseline performance on initial dataset
+2. **Stage 2 Results**: Best hyperparameter configuration and improvement
+3. **Stage 3 Results**: Novel improvements and their impact across 3 datasets
+4. **Stage 4 Results**: Ablation study findings — which components matter most
+5. **Output directory**: Full path to experiment results
+6. **Figures generated**: List of publication-ready plots
+7. **Next step suggestion**: Run `/ai-scientist-writeup $EXPERIMENT_DIR` to generate a paper
+
+## Error Handling
+
+- If a stage completely fails (all attempts produce errors), log the failure and proceed to the next stage with the best available code from previous stages
+- If GPU is not available, fall back to CPU with a warning
+- If a dataset download fails, try an alternative dataset
+- Never spend more than 5 attempts debugging the same error — try a different approach
+
+## Parallelism with Agent Tool
+
+For Stage 4 ablations, you MAY use the **Agent tool** to run multiple ablation experiments in parallel. Each agent should:
+1. Receive the base Stage 3 code
+2. Implement a specific ablation
+3. Execute and return results
+
+This speeds up the ablation stage significantly.

--- a/.claude/skills/ai-scientist-experiment/SKILL.md
+++ b/.claude/skills/ai-scientist-experiment/SKILL.md
@@ -1,26 +1,39 @@
 ---
 name: ai-scientist-experiment
-description: Run AI Scientist v2 best-first tree search experiments on a research idea (without writeup or review)
+description: Run AI Scientist v2 best-first tree search experiments — requires API keys for parallel LLM code generation
 disable-model-invocation: true
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 argument-hint: <ideas-json-path> [--idea_idx N] [--load_code] [--add_dataset_ref]
 ---
 
-# AI Scientist v2 — Experiment Execution Only
+# AI Scientist v2 — Experiment Execution
 
-You are running just the experiment stage of AI Scientist v2. This performs best-first tree search (BFTS) to explore and validate a research idea through code generation, execution, and evaluation.
+Run the best-first tree search (BFTS) experiments. **This stage requires API keys** because it performs parallel LLM-driven code generation and execution that cannot be replicated within a single Claude Code session.
 
 ## Prerequisites
 
-1. **API keys** — Required for the models specified in `bfts_config.yaml` (Anthropic Bedrock for coding, OpenAI for feedback by default).
-2. **GPU** — CUDA-capable GPU required.
-3. **Ideas file** — Pre-generated ideas JSON (from `/ai-scientist-ideate`).
+1. **API keys** — Required for models in `bfts_config.yaml`:
+   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME` for Bedrock (default coding model)
+   - `OPENAI_API_KEY` for feedback model (GPT-4o)
+2. **GPU** — CUDA-capable GPU required for experiment execution
+3. **Ideas file** — Pre-generated ideas JSON (from `/ai-scientist-ideate`)
+4. **Dependencies** — `pip install -r requirements.txt` must have been run
 
-## Usage
+## Verify Environment
 
-Parse `$ARGUMENTS`:
+Before running, check:
 
-- **Positional arg 1** (`$0`): Path to ideas JSON file (required)
+```bash
+python -c "import torch; print(f'CUDA available: {torch.cuda.is_available()}, GPUs: {torch.cuda.device_count()}')"
+echo "OPENAI_API_KEY set: ${OPENAI_API_KEY:+yes}"
+echo "AWS_ACCESS_KEY_ID set: ${AWS_ACCESS_KEY_ID:+yes}"
+```
+
+If keys are missing, inform the user which are needed and stop.
+
+## Arguments
+
+- **Positional arg 1** (`$ARGUMENTS` first word): Path to ideas JSON file (required)
 - `--idea_idx N`: Which idea to run (default: 0)
 - `--load_code`: Also load the companion `.py` starter code file
 - `--add_dataset_ref`: Include HuggingFace dataset reference code
@@ -30,39 +43,41 @@ Parse `$ARGUMENTS`:
 
 ```bash
 cd /home/user/AI-Scientist-v2
-
 export AI_SCIENTIST_ROOT=/home/user/AI-Scientist-v2
 
 python launch_scientist_bfts.py \
-  --load_ideas "$0" \
+  --load_ideas "$IDEAS_PATH" \
+  --idea_idx ${IDEA_IDX:-0} \
   --skip_writeup \
   --skip_review \
-  [other flags from $ARGUMENTS]
+  ${LOAD_CODE:+--load_code} \
+  ${ADD_DATASET_REF:+--add_dataset_ref} \
+  --model_agg_plots "${MODEL_AGG_PLOTS:-o3-mini-2025-01-31}"
 ```
 
-**This is a long-running process** (typically 2-6 hours depending on config). Run with `run_in_background: true`.
+**This is a long-running process** (typically 2-6 hours). Run it with `run_in_background: true` on the Bash tool.
 
 ## Configuration
 
-The experiment is controlled by `bfts_config.yaml`. Key settings:
+The experiment is controlled by `bfts_config.yaml` in the project root. Key settings:
 - `agent.num_workers`: Parallel exploration paths (default: 4)
-- `agent.stages.stage{1-4}_max_iters`: Iterations per stage
-- `agent.code.model`: LLM for code generation
-- `agent.feedback.model`: LLM for evaluating results
-- `exec.timeout`: Per-execution timeout in seconds
-
-The 4 experiment stages:
-1. **Initial Implementation** — Baseline methods
-2. **Baseline Tuning** — Optimization and tuning
-3. **Creative Research** — Novel algorithmic improvements
-4. **Ablation Studies** — Component analysis
+- `agent.stages.stage{1-4}_max_iters`: Max iterations per stage (20, 12, 12, 18)
+- `agent.code.model`: LLM for code generation (default: Claude 3.5 Sonnet via Bedrock)
+- `agent.feedback.model`: LLM for evaluating results (default: GPT-4o)
+- `exec.timeout`: Per-execution timeout in seconds (default: 3600)
 
 ## Output
 
 Results in `experiments/{timestamp}_{idea_name}_attempt_{id}/`:
-- `logs/` — Full experiment logs
-- `logs/tree_plot.html` — Interactive tree visualization
+- `idea.md` / `idea.json` — The research idea
+- `logs/` — Full experiment logs and tree visualization
+- `logs/0-run/baseline_summary.json` — Baseline stage results
+- `logs/0-run/research_summary.json` — Research stage results
+- `logs/0-run/ablation_summary.json` — Ablation stage results
 - `figures/` — Aggregated plots
 - `token_tracker.json` — API cost tracking
 
-After completion, summarize key metrics and findings from the experiment logs.
+After completion, tell the user they can generate a paper with:
+```
+/ai-scientist-writeup experiments/<dir>/
+```

--- a/.claude/skills/ai-scientist-ideate/SKILL.md
+++ b/.claude/skills/ai-scientist-ideate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-scientist-ideate
-description: Generate research ideas for AI Scientist v2 — uses Claude Code directly, no API keys required
+description: Generate research ideas for AI Scientist v2 — uses Claude Code directly with Semantic Scholar for literature search
 disable-model-invocation: true
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
 argument-hint: <workshop-topic-file.md> [--max-num-generations N] [--num-reflections N]
@@ -8,7 +8,15 @@ argument-hint: <workshop-topic-file.md> [--max-num-generations N] [--num-reflect
 
 # AI Scientist v2 — Idea Generation (Claude Code Native)
 
-You are an experienced AI researcher generating high-impact research ideas. This skill runs entirely within Claude Code — **no API keys required**.
+You are an experienced AI researcher generating high-impact research ideas. This skill runs within Claude Code using Semantic Scholar for literature search.
+
+## Environment
+
+- **S2_API_KEY**: Required for Semantic Scholar API access. Verify it is set before proceeding:
+  ```bash
+  echo "S2_API_KEY: ${S2_API_KEY:+set}"
+  ```
+  If not set, warn the user and fall back to WebSearch.
 
 ## Arguments
 
@@ -47,12 +55,24 @@ For each idea (up to max-num-generations), follow this process:
 
 ### 2a. Literature Search
 
-Use **WebSearch** to find relevant recent papers on the topic. Search for:
+Use **Semantic Scholar** to find relevant papers. Run searches via the existing Python tool:
+
+```bash
+cd /home/user/AI-Scientist-v2
+python -c "
+from ai_scientist.tools.semantic_scholar import SemanticScholarSearchTool
+tool = SemanticScholarSearchTool(max_results=10)
+result = tool.use_tool('YOUR SEARCH QUERY HERE')
+print(result)
+"
+```
+
+For each idea, perform at least 2-3 searches to ground it in existing literature:
 - The main topic keywords
 - Specific sub-areas relevant to the idea you're developing
 - Recent advances and open problems
 
-Perform at least 2-3 searches per idea to ground it in existing literature.
+If Semantic Scholar is unavailable (no API key or rate limited), fall back to **WebSearch**.
 
 ### 2b. Idea Generation
 

--- a/.claude/skills/ai-scientist-ideate/SKILL.md
+++ b/.claude/skills/ai-scientist-ideate/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: ai-scientist-ideate
+description: Generate research ideas for AI Scientist v2 using LLM-powered ideation with Semantic Scholar integration
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+argument-hint: <workshop-topic-file.md> [--model MODEL] [--max-num-generations N] [--num-reflections N]
+---
+
+# AI Scientist v2 — Idea Generation
+
+You are running the AI Scientist v2 ideation stage. This generates structured research ideas from a workshop topic description.
+
+## Prerequisites
+
+1. **API key** — `OPENAI_API_KEY` or equivalent must be set for the chosen model.
+2. **Semantic Scholar API key** — `S2_API_KEY` is optional but recommended for better literature search.
+3. **Workshop topic file** — A markdown file describing the research area. Must be placed in `ai_scientist/ideas/`.
+
+## Workshop Topic File Format
+
+If the user provides a topic but no file, create one at `ai_scientist/ideas/<topic_name>.md` with this structure:
+
+```markdown
+# Title: <Workshop/Topic Title>
+
+## Keywords
+keyword1, keyword2, keyword3
+
+## TL;DR
+<One-sentence summary of the research direction>
+
+## Abstract
+<Detailed description of the research area, goals, and scope (~250 words)>
+```
+
+## Usage
+
+Parse `$ARGUMENTS`:
+
+- **Positional arg 1** (`$0`): Path to workshop topic markdown file (required)
+- `--model MODEL`: LLM to use (default: gpt-4o-2024-05-13). Options: !`cd /home/user/AI-Scientist-v2 && python -c "from ai_scientist.llm import AVAILABLE_LLMS; print(', '.join(AVAILABLE_LLMS))" 2>/dev/null || echo "gpt-4o-2024-05-13, claude-3-5-sonnet-20241022, o1-preview-2024-09-12"`
+- `--max-num-generations N`: Number of ideas to generate (default: 20)
+- `--num-reflections N`: Refinement rounds per idea (default: 5)
+
+## Execution
+
+```bash
+cd /home/user/AI-Scientist-v2
+
+python ai_scientist/perform_ideation_temp_free.py \
+  --workshop-file "$0" \
+  --model "${MODEL:-gpt-4o-2024-05-13}" \
+  --max-num-generations "${MAX_GENS:-20}" \
+  --num-reflections "${NUM_REFLECTIONS:-5}"
+```
+
+This is a moderately long-running process. Run it with `run_in_background: true`.
+
+## Output
+
+The script produces a JSON file alongside the input markdown file with the same base name:
+- `ai_scientist/ideas/<topic_name>.json`
+
+Each idea in the JSON contains:
+- **Name**: Short identifier
+- **Title**: Paper title
+- **Short Hypothesis**: Core research question
+- **Related Work**: Literature context
+- **Abstract**: ~250 word summary
+- **Experiments**: Detailed experiment plans
+- **Risk Factors and Limitations**: Known risks
+
+After completion, report how many ideas were generated and list their titles.
+
+The user can then run `/ai-scientist <path-to-ideas.json>` to execute experiments on a selected idea.

--- a/.claude/skills/ai-scientist-ideate/SKILL.md
+++ b/.claude/skills/ai-scientist-ideate/SKILL.md
@@ -1,24 +1,32 @@
 ---
 name: ai-scientist-ideate
-description: Generate research ideas for AI Scientist v2 using LLM-powered ideation with Semantic Scholar integration
+description: Generate research ideas for AI Scientist v2 — uses Claude Code directly, no API keys required
 disable-model-invocation: true
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep
-argument-hint: <workshop-topic-file.md> [--model MODEL] [--max-num-generations N] [--num-reflections N]
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
+argument-hint: <workshop-topic-file.md> [--max-num-generations N] [--num-reflections N]
 ---
 
-# AI Scientist v2 — Idea Generation
+# AI Scientist v2 — Idea Generation (Claude Code Native)
 
-You are running the AI Scientist v2 ideation stage. This generates structured research ideas from a workshop topic description.
+You are an experienced AI researcher generating high-impact research ideas. This skill runs entirely within Claude Code — **no API keys required**.
 
-## Prerequisites
+## Arguments
 
-1. **API key** — `OPENAI_API_KEY` or equivalent must be set for the chosen model.
-2. **Semantic Scholar API key** — `S2_API_KEY` is optional but recommended for better literature search.
-3. **Workshop topic file** — A markdown file describing the research area. Must be placed in `ai_scientist/ideas/`.
+- **Positional arg 1** (`$ARGUMENTS` first word): Path to workshop topic markdown file
+- `--max-num-generations N`: Number of ideas to generate (default: 5)
+- `--num-reflections N`: Refinement rounds per idea (default: 3)
 
-## Workshop Topic File Format
+If no file is provided, ask the user for a research topic.
 
-If the user provides a topic but no file, create one at `ai_scientist/ideas/<topic_name>.md` with this structure:
+## Step 1: Load the Workshop Topic
+
+Read the workshop topic markdown file. It should contain:
+- Title
+- Keywords
+- TL;DR
+- Abstract describing the research area
+
+If the user provides a topic description but no file exists, create one at `ai_scientist/ideas/<topic_name>.md` with this structure:
 
 ```markdown
 # Title: <Workshop/Topic Title>
@@ -27,49 +35,99 @@ If the user provides a topic but no file, create one at `ai_scientist/ideas/<top
 keyword1, keyword2, keyword3
 
 ## TL;DR
-<One-sentence summary of the research direction>
+<One-sentence summary>
 
 ## Abstract
-<Detailed description of the research area, goals, and scope (~250 words)>
+<Detailed description ~250 words>
 ```
 
-## Usage
+## Step 2: Generate Ideas Iteratively
 
-Parse `$ARGUMENTS`:
+For each idea (up to max-num-generations), follow this process:
 
-- **Positional arg 1** (`$0`): Path to workshop topic markdown file (required)
-- `--model MODEL`: LLM to use (default: gpt-4o-2024-05-13). Options: !`cd /home/user/AI-Scientist-v2 && python -c "from ai_scientist.llm import AVAILABLE_LLMS; print(', '.join(AVAILABLE_LLMS))" 2>/dev/null || echo "gpt-4o-2024-05-13, claude-3-5-sonnet-20241022, o1-preview-2024-09-12"`
-- `--max-num-generations N`: Number of ideas to generate (default: 20)
-- `--num-reflections N`: Refinement rounds per idea (default: 5)
+### 2a. Literature Search
 
-## Execution
+Use **WebSearch** to find relevant recent papers on the topic. Search for:
+- The main topic keywords
+- Specific sub-areas relevant to the idea you're developing
+- Recent advances and open problems
 
-```bash
-cd /home/user/AI-Scientist-v2
+Perform at least 2-3 searches per idea to ground it in existing literature.
 
-python ai_scientist/perform_ideation_temp_free.py \
-  --workshop-file "$0" \
-  --model "${MODEL:-gpt-4o-2024-05-13}" \
-  --max-num-generations "${MAX_GENS:-20}" \
-  --num-reflections "${NUM_REFLECTIONS:-5}"
+### 2b. Idea Generation
+
+As an experienced AI researcher, generate a research idea that:
+- Stems from a simple, elegant question or hypothesis
+- Is clearly novel and distinct from existing literature
+- Is feasible for an academic lab (no massive compute requirements)
+- Would be publishable at a top ML conference
+- Includes specific, testable experiments
+
+### 2c. Reflection & Refinement
+
+For each reflection round:
+1. Critically evaluate your idea for quality, novelty, and feasibility
+2. Search for additional related work if needed
+3. Refine the hypothesis, experiments, and framing
+4. Ensure the idea isn't a trivial extension of existing work
+
+### 2d. Finalize Each Idea
+
+Each idea must be a JSON object with exactly these fields:
+
+```json
+{
+  "Name": "lowercase_with_underscores",
+  "Title": "Catchy and informative title",
+  "Short Hypothesis": "Concise statement of the main hypothesis. Clarify the need for this direction and why it's the best setting to investigate.",
+  "Related Work": "Discussion of relevant related work and how this proposal distinguishes from it.",
+  "Abstract": "Conference-format abstract, approximately 250 words.",
+  "Experiments": [
+    "Experiment 1: Specific description with metrics...",
+    "Experiment 2: ..."
+  ],
+  "Risk Factors and Limitations": [
+    "Risk 1: ...",
+    "Risk 2: ..."
+  ]
+}
 ```
 
-This is a moderately long-running process. Run it with `run_in_background: true`.
+**Important**: Each new idea should be distinct from all previously generated ideas. Avoid duplicating themes or approaches.
 
-## Output
+## Step 3: Save Output
 
-The script produces a JSON file alongside the input markdown file with the same base name:
-- `ai_scientist/ideas/<topic_name>.json`
+Save all ideas as a JSON array to a file alongside the input markdown file with the same base name but `.json` extension.
 
-Each idea in the JSON contains:
-- **Name**: Short identifier
-- **Title**: Paper title
-- **Short Hypothesis**: Core research question
-- **Related Work**: Literature context
-- **Abstract**: ~250 word summary
-- **Experiments**: Detailed experiment plans
-- **Risk Factors and Limitations**: Known risks
+For example: `ai_scientist/ideas/my_topic.md` → `ai_scientist/ideas/my_topic.json`
 
-After completion, report how many ideas were generated and list their titles.
+```python
+# The output file is a JSON array of idea objects:
+[
+  { "Name": "idea_1", "Title": "...", ... },
+  { "Name": "idea_2", "Title": "...", ... }
+]
+```
 
-The user can then run `/ai-scientist <path-to-ideas.json>` to execute experiments on a selected idea.
+Write the file using the Write tool.
+
+## Step 4: Report Results
+
+After generating all ideas, list them with:
+- Index number
+- Title
+- One-line hypothesis summary
+
+Tell the user they can run experiments with:
+```
+/ai-scientist-experiment ai_scientist/ideas/<topic>.json --idea_idx <N>
+```
+
+## Guidelines
+
+- Be very creative and think out of the box
+- Each proposal should stem from a simple and elegant question
+- Proposals should explore new possibilities or challenge existing assumptions
+- Ensure feasibility — no resources beyond what an academic lab could afford
+- Perform literature searches to ensure novelty
+- Keep experiments specific: detail exact algorithmic changes and evaluation metrics

--- a/.claude/skills/ai-scientist-review/SKILL.md
+++ b/.claude/skills/ai-scientist-review/SKILL.md
@@ -1,90 +1,158 @@
 ---
 name: ai-scientist-review
-description: Perform AI-powered peer review of a generated scientific paper (text + figure/caption review)
+description: Perform AI peer review of a scientific paper — uses Claude Code directly, no API keys required
 disable-model-invocation: true
-allowed-tools: Bash, Read, Glob, Grep
-argument-hint: <experiment-dir> [--model_review MODEL]
+allowed-tools: Bash, Read, Write, Glob, Grep
+argument-hint: <experiment-dir>
 ---
 
-# AI Scientist v2 — Paper Review
+# AI Scientist v2 — Paper Review (Claude Code Native)
 
-You are running the peer review stage of AI Scientist v2. This performs both text-based and vision-based review of a generated scientific paper.
+You are an expert peer reviewer for a top ML conference (NeurIPS). Review the paper thoroughly and critically. This skill runs entirely within Claude Code — **no API keys required**.
 
-## Prerequisites
+## Arguments
 
-1. **Generated paper** — A PDF file in the experiment directory (from `/ai-scientist-writeup` or `/ai-scientist`).
-2. **API key** — `OPENAI_API_KEY` for the review model (default: gpt-4o).
+- **Positional arg 1** (`$ARGUMENTS` first word): Path to experiment directory containing the PDF
 
-## Usage
-
-Parse `$ARGUMENTS`:
-
-- **Positional arg 1** (`$0`): Path to experiment directory containing the PDF
-- `--model_review MODEL`: Model for review (default: gpt-4o-2024-11-20)
-
-## Execution
+## Step 1: Find and Load the Paper
 
 ```bash
-cd /home/user/AI-Scientist-v2
-export AI_SCIENTIST_ROOT=/home/user/AI-Scientist-v2
-
-python -c "
-import os, json, re
-from ai_scientist.llm import create_client
-from ai_scientist.perform_llm_review import perform_review, load_paper
-from ai_scientist.perform_vlm_review import perform_imgs_cap_ref_review
-
-experiment_dir = '$0'
-model_name = '${MODEL_REVIEW:-gpt-4o-2024-11-20}'
-
-# Find the PDF
-pdf_files = [f for f in os.listdir(experiment_dir) if f.endswith('.pdf')]
-reflection_pdfs = [f for f in pdf_files if 'reflection' in f]
-if reflection_pdfs:
-    final_pdfs = [f for f in reflection_pdfs if 'final' in f.lower()]
-    if final_pdfs:
-        pdf_path = os.path.join(experiment_dir, final_pdfs[0])
-    else:
-        nums = []
-        for f in reflection_pdfs:
-            m = re.search(r'reflection[_.]?(\d+)', f)
-            if m: nums.append((int(m.group(1)), f))
-        if nums:
-            pdf_path = os.path.join(experiment_dir, max(nums, key=lambda x: x[0])[1])
-        else:
-            pdf_path = os.path.join(experiment_dir, reflection_pdfs[0])
-elif pdf_files:
-    pdf_path = os.path.join(experiment_dir, pdf_files[0])
-else:
-    print('No PDF found!')
-    exit(1)
-
-print(f'Reviewing: {pdf_path}')
-
-# Text review
-paper_content = load_paper(pdf_path)
-client, client_model = create_client(model_name)
-review_text = perform_review(paper_content, client_model, client)
-
-with open(os.path.join(experiment_dir, 'review_text.txt'), 'w') as f:
-    f.write(json.dumps(review_text, indent=4))
-
-# Figure review
-review_img = perform_imgs_cap_ref_review(client, client_model, pdf_path)
-with open(os.path.join(experiment_dir, 'review_img_cap_ref.json'), 'w') as f:
-    json.dump(review_img, f, indent=4)
-
-print('Review complete!')
-"
+# Find the PDF in the experiment directory
+ls <experiment-dir>/*.pdf
 ```
 
-## Output
+If multiple PDFs exist, prefer:
+1. Files containing "reflection_final" in the name
+2. Files with the highest reflection number
+3. The most recently modified PDF
 
-- `review_text.txt` — Full text review with scores and feedback
-- `review_img_cap_ref.json` — Figure, caption, and reference review
+Convert the PDF to readable text:
 
-After completion, read and summarize the review results for the user, highlighting:
-- Overall score and recommendation
-- Key strengths identified
-- Main weaknesses and suggestions
-- Figure quality assessment
+```bash
+pdftotext <pdf-path> -
+```
+
+Also read the PDF directly using the Read tool (it supports PDF files) to see figures.
+
+Read the research idea from `<experiment-dir>/idea.md` or `<experiment-dir>/idea.json` for context.
+
+## Step 2: Text Review
+
+Review the paper following the **NeurIPS review form**. Evaluate:
+
+### Review Criteria
+
+1. **Summary**: Summarize what the paper claims to contribute in 2-3 sentences
+
+2. **Strengths**: List key strengths as bullet points. Consider:
+   - Novelty and originality of the approach
+   - Technical soundness and rigor
+   - Clarity of presentation
+   - Significance of results
+   - Quality of experiments
+
+3. **Weaknesses**: List key weaknesses as bullet points. Consider:
+   - Missing baselines or comparisons
+   - Questionable assumptions or methodology
+   - Insufficient experiments or analysis
+   - Writing quality issues
+   - Overclaimed results
+
+4. **Questions**: List questions for the authors
+
+5. **Limitations**: Note whether the paper adequately discusses limitations
+
+6. **Scores** (provide numerical ratings):
+   - **Soundness** (1-4): 1=poor, 2=fair, 3=good, 4=excellent
+   - **Presentation** (1-4): 1=poor, 2=fair, 3=good, 4=excellent
+   - **Contribution** (1-4): 1=poor, 2=fair, 3=good, 4=excellent
+   - **Originality** (1-4): 1=low, 2=medium, 3=high, 4=very high
+   - **Quality** (1-4): 1=low, 2=medium, 3=high, 4=very high
+   - **Clarity** (1-4): 1=low, 2=medium, 3=high, 4=very high
+   - **Significance** (1-4): 1=low, 2=medium, 3=high, 4=very high
+   - **Overall** (1-10): 1=very strong reject, 3=clear reject, 5=marginally below, 6=marginally above, 8=clear accept, 10=award quality
+   - **Confidence** (1-5): 1=low, 3=moderate, 5=absolute certainty
+
+7. **Decision**: "Accept" or "Reject"
+
+### Review Guidelines
+
+- Be critical but fair — if unsure about quality, lean toward rejection
+- Focus on the scientific contribution, not just writing quality
+- Check that all claims are supported by evidence
+- Verify figures match the text discussion
+- Check for missing references to related work
+- Assess whether experiments are sufficient to support the claims
+
+## Step 3: Figure Review
+
+Using the Read tool to view the PDF, evaluate each figure:
+
+1. **Description**: What does the figure show?
+2. **Quality**: Is it clear, well-labeled, with proper legends?
+3. **Caption**: Is the caption accurate and informative?
+4. **Relevance**: Is the figure discussed adequately in the main text?
+5. **Suggestions**: How could the figure be improved?
+
+Check for:
+- Duplicate or near-duplicate figures
+- Figures not referenced in the text
+- Missing axis labels or legends
+- Figures that don't support their captions
+
+## Step 4: Save Review Output
+
+Save the text review as JSON:
+
+```json
+{
+  "Summary": "...",
+  "Strengths": ["...", "..."],
+  "Weaknesses": ["...", "..."],
+  "Originality": 3,
+  "Quality": 3,
+  "Clarity": 3,
+  "Significance": 2,
+  "Soundness": 3,
+  "Presentation": 3,
+  "Contribution": 2,
+  "Questions": ["...", "..."],
+  "Limitations": ["...", "..."],
+  "Ethical Concerns": false,
+  "Overall": 5,
+  "Confidence": 3,
+  "Decision": "Reject"
+}
+```
+
+Write to `<experiment-dir>/review_text.txt` using:
+```python
+json.dumps(review, indent=4)
+```
+
+Save the figure review as JSON to `<experiment-dir>/review_img_cap_ref.json`:
+```json
+{
+  "figures": [
+    {
+      "figure_name": "figure_1",
+      "description": "...",
+      "quality_review": "...",
+      "caption_review": "...",
+      "relevance_review": "..."
+    }
+  ],
+  "duplicate_figures": [],
+  "overall_figure_quality": "..."
+}
+```
+
+## Step 5: Report Results
+
+Present the review to the user in a readable format:
+
+1. **Decision**: Accept/Reject with overall score
+2. **Key Strengths**: Top 2-3 strengths
+3. **Key Weaknesses**: Top 2-3 weaknesses
+4. **Figure Assessment**: Overall quality of figures
+5. **Recommendation**: Brief actionable suggestion for improvement

--- a/.claude/skills/ai-scientist-review/SKILL.md
+++ b/.claude/skills/ai-scientist-review/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: ai-scientist-review
+description: Perform AI-powered peer review of a generated scientific paper (text + figure/caption review)
+disable-model-invocation: true
+allowed-tools: Bash, Read, Glob, Grep
+argument-hint: <experiment-dir> [--model_review MODEL]
+---
+
+# AI Scientist v2 — Paper Review
+
+You are running the peer review stage of AI Scientist v2. This performs both text-based and vision-based review of a generated scientific paper.
+
+## Prerequisites
+
+1. **Generated paper** — A PDF file in the experiment directory (from `/ai-scientist-writeup` or `/ai-scientist`).
+2. **API key** — `OPENAI_API_KEY` for the review model (default: gpt-4o).
+
+## Usage
+
+Parse `$ARGUMENTS`:
+
+- **Positional arg 1** (`$0`): Path to experiment directory containing the PDF
+- `--model_review MODEL`: Model for review (default: gpt-4o-2024-11-20)
+
+## Execution
+
+```bash
+cd /home/user/AI-Scientist-v2
+export AI_SCIENTIST_ROOT=/home/user/AI-Scientist-v2
+
+python -c "
+import os, json, re
+from ai_scientist.llm import create_client
+from ai_scientist.perform_llm_review import perform_review, load_paper
+from ai_scientist.perform_vlm_review import perform_imgs_cap_ref_review
+
+experiment_dir = '$0'
+model_name = '${MODEL_REVIEW:-gpt-4o-2024-11-20}'
+
+# Find the PDF
+pdf_files = [f for f in os.listdir(experiment_dir) if f.endswith('.pdf')]
+reflection_pdfs = [f for f in pdf_files if 'reflection' in f]
+if reflection_pdfs:
+    final_pdfs = [f for f in reflection_pdfs if 'final' in f.lower()]
+    if final_pdfs:
+        pdf_path = os.path.join(experiment_dir, final_pdfs[0])
+    else:
+        nums = []
+        for f in reflection_pdfs:
+            m = re.search(r'reflection[_.]?(\d+)', f)
+            if m: nums.append((int(m.group(1)), f))
+        if nums:
+            pdf_path = os.path.join(experiment_dir, max(nums, key=lambda x: x[0])[1])
+        else:
+            pdf_path = os.path.join(experiment_dir, reflection_pdfs[0])
+elif pdf_files:
+    pdf_path = os.path.join(experiment_dir, pdf_files[0])
+else:
+    print('No PDF found!')
+    exit(1)
+
+print(f'Reviewing: {pdf_path}')
+
+# Text review
+paper_content = load_paper(pdf_path)
+client, client_model = create_client(model_name)
+review_text = perform_review(paper_content, client_model, client)
+
+with open(os.path.join(experiment_dir, 'review_text.txt'), 'w') as f:
+    f.write(json.dumps(review_text, indent=4))
+
+# Figure review
+review_img = perform_imgs_cap_ref_review(client, client_model, pdf_path)
+with open(os.path.join(experiment_dir, 'review_img_cap_ref.json'), 'w') as f:
+    json.dump(review_img, f, indent=4)
+
+print('Review complete!')
+"
+```
+
+## Output
+
+- `review_text.txt` — Full text review with scores and feedback
+- `review_img_cap_ref.json` — Figure, caption, and reference review
+
+After completion, read and summarize the review results for the user, highlighting:
+- Overall score and recommendation
+- Key strengths identified
+- Main weaknesses and suggestions
+- Figure quality assessment

--- a/.claude/skills/ai-scientist-writeup/SKILL.md
+++ b/.claude/skills/ai-scientist-writeup/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: ai-scientist-writeup
+description: Generate a scientific paper from completed AI Scientist v2 experiment results
+disable-model-invocation: true
+allowed-tools: Bash, Read, Glob, Grep
+argument-hint: <experiment-dir> [--writeup-type normal|icbinb] [--model_writeup MODEL] [--num_cite_rounds N]
+---
+
+# AI Scientist v2 — Paper Writeup
+
+You are running the paper generation stage of AI Scientist v2. This takes completed experiment results and produces a full scientific manuscript in LaTeX/PDF format.
+
+## Prerequisites
+
+1. **Completed experiments** — An experiment directory with results (from `/ai-scientist-experiment` or `/ai-scientist`).
+2. **API keys** — `OPENAI_API_KEY` for the writeup and citation models.
+3. **LaTeX** — `pdflatex` and `bibtex` must be installed.
+4. **Semantic Scholar** — `S2_API_KEY` recommended for citation gathering.
+
+## Usage
+
+Parse `$ARGUMENTS`:
+
+- **Positional arg 1** (`$0`): Path to experiment directory (e.g., `experiments/2025-01-01_my_idea_attempt_0`)
+- `--writeup-type TYPE`: `normal` (8-page ICML) or `icbinb` (4-page workshop). Default: `icbinb`
+- `--model_writeup MODEL`: Model for paper writing (default: o1-preview-2024-09-12)
+- `--model_writeup_small MODEL`: Secondary model (default: gpt-4o-2024-05-13)
+- `--model_citation MODEL`: Model for citations (default: gpt-4o-2024-11-20)
+- `--num_cite_rounds N`: Citation search rounds (default: 20)
+
+## Execution
+
+This stage involves two sub-steps run sequentially:
+
+### Step 1: Gather Citations
+```python
+from ai_scientist.perform_icbinb_writeup import gather_citations
+gather_citations(experiment_dir, num_cite_rounds=20, small_model="gpt-4o-2024-11-20")
+```
+
+### Step 2: Generate Paper
+```python
+# For ICBINB (4-page):
+from ai_scientist.perform_icbinb_writeup import perform_writeup
+perform_writeup(base_folder=experiment_dir, small_model=..., big_model=..., page_limit=4, citations_text=...)
+
+# For normal (8-page):
+from ai_scientist.perform_writeup import perform_writeup
+perform_writeup(base_folder=experiment_dir, small_model=..., big_model=..., page_limit=8, citations_text=...)
+```
+
+Run via a Python script:
+
+```bash
+cd /home/user/AI-Scientist-v2
+export AI_SCIENTIST_ROOT=/home/user/AI-Scientist-v2
+
+python -c "
+import sys, json
+from ai_scientist.perform_icbinb_writeup import gather_citations, perform_writeup
+
+experiment_dir = '$0'
+citations_text = gather_citations(experiment_dir, num_cite_rounds=20, small_model='gpt-4o-2024-11-20')
+
+for attempt in range(3):
+    print(f'Writeup attempt {attempt+1}/3')
+    success = perform_writeup(
+        base_folder=experiment_dir,
+        small_model='gpt-4o-2024-05-13',
+        big_model='o1-preview-2024-09-12',
+        page_limit=4,
+        citations_text=citations_text,
+    )
+    if success:
+        print('Writeup successful!')
+        break
+else:
+    print('Writeup failed after 3 attempts')
+"
+```
+
+This is a long-running process. Run with `run_in_background: true`.
+
+## Output
+
+- `{experiment_dir}/*.pdf` — The generated paper
+- `{experiment_dir}/token_tracker.json` — Updated cost tracking
+
+After completion, report the PDF path and any errors.

--- a/.claude/skills/ai-scientist-writeup/SKILL.md
+++ b/.claude/skills/ai-scientist-writeup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-scientist-writeup
-description: Generate a scientific paper from completed AI Scientist v2 experiments — uses Claude Code directly, no API keys required
+description: Generate a scientific paper from completed AI Scientist v2 experiments — uses Claude Code directly with Semantic Scholar for citations
 disable-model-invocation: true
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
 argument-hint: <experiment-dir> [--writeup-type normal|icbinb]
@@ -8,7 +8,7 @@ argument-hint: <experiment-dir> [--writeup-type normal|icbinb]
 
 # AI Scientist v2 — Paper Writeup (Claude Code Native)
 
-You are a scientific paper writer generating a complete LaTeX manuscript from experiment results. This skill runs entirely within Claude Code — **no API keys required**.
+You are a scientific paper writer generating a complete LaTeX manuscript from experiment results. This skill runs within Claude Code using Semantic Scholar for citation gathering.
 
 ## Arguments
 
@@ -47,11 +47,38 @@ Read the template file at `<experiment-dir>/latex/template.tex`.
 
 ## Step 3: Gather Citations
 
-Use **WebSearch** to find relevant papers for citation. For each major claim or comparison in the experiment results:
+Use **Semantic Scholar** to find relevant papers for citation. For each major topic, claim, or comparison in the experiment results, search for papers:
 
-1. Search for the most relevant papers (at least 10-15 total citations)
-2. For each paper found, create a BibTeX entry
-3. Add all citations to the `references.bib` filecontents block in `template.tex`
+```bash
+cd /home/user/AI-Scientist-v2
+python -c "
+from ai_scientist.tools.semantic_scholar import search_for_papers
+import json
+
+papers = search_for_papers('YOUR SEARCH QUERY', result_limit=5)
+if papers:
+    for p in papers:
+        authors = ', '.join([a.get('name','') for a in p.get('authors',[])])
+        print(f\"Title: {p.get('title')}\")
+        print(f\"Authors: {authors}\")
+        print(f\"Venue: {p.get('venue')}, Year: {p.get('year')}\")
+        print(f\"Citations: {p.get('citationCount')}\")
+        cite = p.get('citationStyles', {}).get('bibtex', '')
+        if cite:
+            print(f'BibTeX: {cite}')
+        print('---')
+"
+```
+
+Perform at least 5-8 separate searches covering different aspects of the paper (method, baselines, datasets, related work, etc.) to gather 10-15+ citations.
+
+For each paper found:
+1. Use the BibTeX from Semantic Scholar's `citationStyles.bibtex` field if available
+2. Otherwise, create a BibTeX entry manually
+3. Clean citation keys: lowercase, no accents/special chars, format `authorYYYYkeyword`
+4. Add all citations to the `references.bib` filecontents block in `template.tex`
+
+If Semantic Scholar is unavailable, fall back to **WebSearch**.
 
 BibTeX entries should follow this format:
 ```bibtex

--- a/.claude/skills/ai-scientist-writeup/SKILL.md
+++ b/.claude/skills/ai-scientist-writeup/SKILL.md
@@ -1,89 +1,142 @@
 ---
 name: ai-scientist-writeup
-description: Generate a scientific paper from completed AI Scientist v2 experiment results
+description: Generate a scientific paper from completed AI Scientist v2 experiments — uses Claude Code directly, no API keys required
 disable-model-invocation: true
-allowed-tools: Bash, Read, Glob, Grep
-argument-hint: <experiment-dir> [--writeup-type normal|icbinb] [--model_writeup MODEL] [--num_cite_rounds N]
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
+argument-hint: <experiment-dir> [--writeup-type normal|icbinb]
 ---
 
-# AI Scientist v2 — Paper Writeup
+# AI Scientist v2 — Paper Writeup (Claude Code Native)
 
-You are running the paper generation stage of AI Scientist v2. This takes completed experiment results and produces a full scientific manuscript in LaTeX/PDF format.
+You are a scientific paper writer generating a complete LaTeX manuscript from experiment results. This skill runs entirely within Claude Code — **no API keys required**.
 
-## Prerequisites
+## Arguments
 
-1. **Completed experiments** — An experiment directory with results (from `/ai-scientist-experiment` or `/ai-scientist`).
-2. **API keys** — `OPENAI_API_KEY` for the writeup and citation models.
-3. **LaTeX** — `pdflatex` and `bibtex` must be installed.
-4. **Semantic Scholar** — `S2_API_KEY` recommended for citation gathering.
+- **Positional arg 1** (`$ARGUMENTS` first word): Path to experiment directory (e.g., `experiments/2025-01-01_my_idea_attempt_0`)
+- `--writeup-type TYPE`: `icbinb` (4-page workshop, default) or `normal` (8-page conference)
 
-## Usage
+## Step 1: Load Experiment Data
 
-Parse `$ARGUMENTS`:
+Read these files from the experiment directory:
 
-- **Positional arg 1** (`$0`): Path to experiment directory (e.g., `experiments/2025-01-01_my_idea_attempt_0`)
-- `--writeup-type TYPE`: `normal` (8-page ICML) or `icbinb` (4-page workshop). Default: `icbinb`
-- `--model_writeup MODEL`: Model for paper writing (default: o1-preview-2024-09-12)
-- `--model_writeup_small MODEL`: Secondary model (default: gpt-4o-2024-05-13)
-- `--model_citation MODEL`: Model for citations (default: gpt-4o-2024-11-20)
-- `--num_cite_rounds N`: Citation search rounds (default: 20)
+1. **Research idea**: `idea.md` or `research_idea.md`
+2. **Idea JSON**: `idea.json`
+3. **Experiment summaries** (in `logs/0-run/`):
+   - `baseline_summary.json`
+   - `research_summary.json`
+   - `ablation_summary.json`
+4. **Figures**: List all `.png` files in `figures/`
+5. **Plot aggregator script**: `auto_plot_aggregator.py` (if exists)
 
-## Execution
+Read all of these files. The experiment summaries are critical — they contain the full results.
 
-This stage involves two sub-steps run sequentially:
-
-### Step 1: Gather Citations
-```python
-from ai_scientist.perform_icbinb_writeup import gather_citations
-gather_citations(experiment_dir, num_cite_rounds=20, small_model="gpt-4o-2024-11-20")
-```
-
-### Step 2: Generate Paper
-```python
-# For ICBINB (4-page):
-from ai_scientist.perform_icbinb_writeup import perform_writeup
-perform_writeup(base_folder=experiment_dir, small_model=..., big_model=..., page_limit=4, citations_text=...)
-
-# For normal (8-page):
-from ai_scientist.perform_writeup import perform_writeup
-perform_writeup(base_folder=experiment_dir, small_model=..., big_model=..., page_limit=8, citations_text=...)
-```
-
-Run via a Python script:
+## Step 2: Set Up LaTeX Workspace
 
 ```bash
-cd /home/user/AI-Scientist-v2
-export AI_SCIENTIST_ROOT=/home/user/AI-Scientist-v2
+cd <experiment-dir>
 
-python -c "
-import sys, json
-from ai_scientist.perform_icbinb_writeup import gather_citations, perform_writeup
-
-experiment_dir = '$0'
-citations_text = gather_citations(experiment_dir, num_cite_rounds=20, small_model='gpt-4o-2024-11-20')
-
-for attempt in range(3):
-    print(f'Writeup attempt {attempt+1}/3')
-    success = perform_writeup(
-        base_folder=experiment_dir,
-        small_model='gpt-4o-2024-05-13',
-        big_model='o1-preview-2024-09-12',
-        page_limit=4,
-        citations_text=citations_text,
-    )
-    if success:
-        print('Writeup successful!')
-        break
-else:
-    print('Writeup failed after 3 attempts')
-"
+# Choose template based on writeup type
+if [ "$WRITEUP_TYPE" = "normal" ]; then
+  cp -r /home/user/AI-Scientist-v2/ai_scientist/blank_icml_latex latex
+else
+  cp -r /home/user/AI-Scientist-v2/ai_scientist/blank_icbinb_latex latex
+fi
 ```
 
-This is a long-running process. Run with `run_in_background: true`.
+Read the template file at `<experiment-dir>/latex/template.tex`.
 
-## Output
+## Step 3: Gather Citations
 
-- `{experiment_dir}/*.pdf` — The generated paper
-- `{experiment_dir}/token_tracker.json` — Updated cost tracking
+Use **WebSearch** to find relevant papers for citation. For each major claim or comparison in the experiment results:
 
-After completion, report the PDF path and any errors.
+1. Search for the most relevant papers (at least 10-15 total citations)
+2. For each paper found, create a BibTeX entry
+3. Add all citations to the `references.bib` filecontents block in `template.tex`
+
+BibTeX entries should follow this format:
+```bibtex
+@article{authorYYYYkeyword,
+  title={Paper Title},
+  author={Last, First and Last2, First2},
+  journal={Venue},
+  year={YYYY}
+}
+```
+
+## Step 4: Generate Paper Content
+
+Replace the placeholder markers (`%%%%%%%%%SECTION%%%%%%%%%`) in `template.tex` with real content. The template has these sections:
+
+### For ICBINB (4-page, single-column):
+- **Title** and **Abstract** (from the idea)
+- **Introduction**: Motivate the research question, state contributions
+- **Related Work**: Position against existing literature (use citations from Step 3)
+- **Background**: Necessary technical background
+- **Method**: Describe the approach in detail
+- **Experimental Setup**: Datasets, metrics, baselines, hyperparameters
+- **Experiments**: Present results with figures and tables. Reference ALL relevant figures from `figures/`
+- **Conclusion**: Summarize findings, limitations, future work
+- **Appendix**: Additional results, ablations, extra figures
+
+### For Normal (8-page, double-column):
+Same sections plus:
+- **Impact Statement**: Broader impact of the work
+
+### Writing Guidelines:
+
+1. **Figures**: Use `\includegraphics{filename.png}` (the template sets `\graphicspath{{../figures/}}`)
+2. **Page limits**: 4 pages for ICBINB (single-column), 8 pages for normal (double-column), excluding references and appendix
+3. **Accuracy**: Only report results that appear in the experiment summaries. Never hallucinate metrics.
+4. **All results**: Include ALL experiment results truthfully — negative results are valuable, especially for ICBINB
+5. **Figures in main text**: For ICBINB, keep at most 4 figures in main text; move rest to appendix
+6. **No itemize/enumerate abuse**: Use flowing prose, minimize bullet lists
+7. **Citations**: Use `\citep{}` for parenthetical and `\citet{}` for textual citations
+
+### LaTeX Quality:
+- Escape special characters: `%`, `_`, `&`, `#`, `$`
+- Use `\textbf{}` and `\textit{}` for emphasis
+- Tables should use `\begin{table}[h]` with `\centering`
+- Figures should use `\begin{figure}[h]` or `\begin{figure*}` for full-width
+
+## Step 5: Write the LaTeX File
+
+Use the Edit tool to replace the template content section by section. Work through each `%%%%%%%%%MARKER%%%%%%%%%` pair, replacing the placeholder text between them with your generated content.
+
+## Step 6: Compile the Paper
+
+```bash
+cd <experiment-dir>/latex
+pdflatex -interaction=nonstopmode template.tex
+bibtex template
+pdflatex -interaction=nonstopmode template.tex
+pdflatex -interaction=nonstopmode template.tex
+```
+
+## Step 7: Review & Fix Compilation
+
+After compilation:
+
+1. Check for LaTeX errors in the output
+2. Run `chktex template.tex` to find common issues
+3. Check page count: `pdftotext template.pdf - | grep -c "."` or examine the PDF
+4. Fix any issues and recompile (up to 3 attempts)
+
+Common fixes:
+- `</end` → `\end` (common LLM mistake)
+- Unescaped `%` or `_` in text
+- Missing `\usepackage` declarations
+- Overfull hbox warnings (rephrase text or adjust figure sizes)
+
+## Step 8: Finalize
+
+```bash
+cd <experiment-dir>
+FOLDER_NAME=$(basename $(pwd))
+cp latex/template.pdf "${FOLDER_NAME}.pdf"
+```
+
+Report to the user:
+- Path to the generated PDF
+- Page count
+- Any compilation warnings
+- Suggestion to run `/ai-scientist-review <experiment-dir>` for peer review

--- a/.claude/skills/ai-scientist/SKILL.md
+++ b/.claude/skills/ai-scientist/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ai-scientist
+description: Run the full AI Scientist v2 pipeline — autonomous scientific research from idea generation through experiments, paper writing, and review
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent
+argument-hint: <ideas-json-path> [--idea_idx N] [--writeup-type normal|icbinb] [--skip_writeup] [--skip_review]
+---
+
+# AI Scientist v2 — Full Pipeline
+
+You are orchestrating the AI Scientist v2 autonomous research system. This skill runs the complete pipeline: experiments → plot aggregation → citation gathering → paper writeup → peer review.
+
+## Prerequisites
+
+Before running, verify the environment:
+
+1. **API keys** — At least one must be set:
+   - `OPENAI_API_KEY` for OpenAI models
+   - `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_REGION_NAME` for Bedrock
+   - `S2_API_KEY` for Semantic Scholar (optional but recommended)
+
+2. **System dependencies** — Verify these are installed:
+   - `pdflatex` and `bibtex` (LaTeX compilation)
+   - `chktex` (LaTeX checking)
+   - Python with CUDA-enabled PyTorch
+   - Project Python dependencies (`pip install -r requirements.txt`)
+
+3. **Ideas file** — A JSON file with pregenerated research ideas (from `/ai-scientist-ideate`)
+
+## Usage
+
+The user provides arguments via `$ARGUMENTS`. Parse them as follows:
+
+- **Positional arg 1** (`$0`): Path to ideas JSON file (required)
+- `--idea_idx N`: Which idea to run (default: 0)
+- `--writeup-type normal|icbinb`: Paper format — 8-page (normal) or 4-page ICBINB (default: icbinb)
+- `--skip_writeup`: Skip paper generation
+- `--skip_review`: Skip peer review
+- `--model_writeup MODEL`: Model for writeup (default: o1-preview-2024-09-12)
+- `--model_citation MODEL`: Model for citations (default: gpt-4o-2024-11-20)
+- `--model_review MODEL`: Model for review (default: gpt-4o-2024-11-20)
+- `--model_agg_plots MODEL`: Model for plot aggregation (default: o3-mini-2025-01-31)
+- `--num_cite_rounds N`: Citation rounds (default: 20)
+- `--load_code`: Load companion .py file for the ideas
+- `--add_dataset_ref`: Add HuggingFace dataset reference
+
+## Execution
+
+Run the pipeline from the project root directory:
+
+```bash
+cd /home/user/AI-Scientist-v2
+
+export AI_SCIENTIST_ROOT=/home/user/AI-Scientist-v2
+
+python launch_scientist_bfts.py \
+  --load_ideas "$0" \
+  [pass through all other flags from $ARGUMENTS]
+```
+
+**Important notes:**
+- This is a **long-running process** (typically several hours). Run it in the background using `run_in_background: true` on the Bash tool.
+- Monitor progress by tailing log files in the `experiments/` directory.
+- The process uses significant GPU resources.
+
+## Output
+
+Results are saved to `experiments/{timestamp}_{idea_name}_attempt_{id}/` containing:
+- `idea.md` / `idea.json` — The research idea
+- `logs/` — Experiment logs and tree visualization
+- `figures/` — Publication-ready plots
+- `*.pdf` — Generated paper (if writeup enabled)
+- `review_text.txt` — LLM review (if review enabled)
+- `review_img_cap_ref.json` — Figure review (if review enabled)
+- `token_tracker.json` — API cost tracking
+
+After the run completes, report the output directory and key results to the user.
+
+## Error Handling
+
+- If the process fails, check logs in `experiments/*/logs/` for details.
+- Common issues: missing API keys, CUDA out of memory, LaTeX compilation failures.
+- The writeup step retries up to 3 times automatically.

--- a/.claude/skills/ai-scientist/SKILL.md
+++ b/.claude/skills/ai-scientist/SKILL.md
@@ -1,83 +1,100 @@
 ---
 name: ai-scientist
-description: Run the full AI Scientist v2 pipeline — autonomous scientific research from idea generation through experiments, paper writing, and review
+description: Run the full AI Scientist v2 pipeline — ideation through review. Only the experiment stage requires API keys.
 disable-model-invocation: true
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent
-argument-hint: <ideas-json-path> [--idea_idx N] [--writeup-type normal|icbinb] [--skip_writeup] [--skip_review]
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
+argument-hint: <ideas-json-or-topic-md> [--idea_idx N] [--writeup-type normal|icbinb] [--skip_writeup] [--skip_review] [--skip_experiments]
 ---
 
 # AI Scientist v2 — Full Pipeline
 
-You are orchestrating the AI Scientist v2 autonomous research system. This skill runs the complete pipeline: experiments → plot aggregation → citation gathering → paper writeup → peer review.
+Orchestrate the complete AI Scientist v2 research pipeline. Stages that previously required API keys (ideation, writeup, review) now run natively in Claude Code. Only the experiment stage still requires external API keys.
 
-## Prerequisites
+## Arguments
 
-Before running, verify the environment:
+Parse `$ARGUMENTS`:
 
-1. **API keys** — At least one must be set:
-   - `OPENAI_API_KEY` for OpenAI models
-   - `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_REGION_NAME` for Bedrock
-   - `S2_API_KEY` for Semantic Scholar (optional but recommended)
-
-2. **System dependencies** — Verify these are installed:
-   - `pdflatex` and `bibtex` (LaTeX compilation)
-   - `chktex` (LaTeX checking)
-   - Python with CUDA-enabled PyTorch
-   - Project Python dependencies (`pip install -r requirements.txt`)
-
-3. **Ideas file** — A JSON file with pregenerated research ideas (from `/ai-scientist-ideate`)
-
-## Usage
-
-The user provides arguments via `$ARGUMENTS`. Parse them as follows:
-
-- **Positional arg 1** (`$0`): Path to ideas JSON file (required)
-- `--idea_idx N`: Which idea to run (default: 0)
-- `--writeup-type normal|icbinb`: Paper format — 8-page (normal) or 4-page ICBINB (default: icbinb)
+- **Positional arg 1**: Path to either:
+  - A `.json` file with pregenerated ideas (skips ideation)
+  - A `.md` topic file (runs ideation first)
+- `--idea_idx N`: Which idea to run experiments on (default: 0)
+- `--writeup-type TYPE`: `icbinb` (4-page, default) or `normal` (8-page)
+- `--load_code`: Load companion .py starter code
+- `--add_dataset_ref`: Add HuggingFace dataset reference
+- `--skip_experiments`: Skip experiment execution (use existing results)
 - `--skip_writeup`: Skip paper generation
 - `--skip_review`: Skip peer review
-- `--model_writeup MODEL`: Model for writeup (default: o1-preview-2024-09-12)
-- `--model_citation MODEL`: Model for citations (default: gpt-4o-2024-11-20)
-- `--model_review MODEL`: Model for review (default: gpt-4o-2024-11-20)
-- `--model_agg_plots MODEL`: Model for plot aggregation (default: o3-mini-2025-01-31)
-- `--num_cite_rounds N`: Citation rounds (default: 20)
-- `--load_code`: Load companion .py file for the ideas
-- `--add_dataset_ref`: Add HuggingFace dataset reference
+- `--max-num-generations N`: Ideas to generate if running ideation (default: 5)
 
-## Execution
+## Pipeline Stages
 
-Run the pipeline from the project root directory:
+### Stage 1: Ideation (Claude Code Native — No API Keys)
 
+**Only runs if a `.md` file is provided instead of `.json`.**
+
+Invoke the `/ai-scientist-ideate` skill with the topic file. This uses Claude Code's own capabilities and web search for literature review.
+
+After ideation, the JSON file path becomes the input for subsequent stages.
+
+### Stage 2: Experiments (Requires API Keys)
+
+**Skipped if `--skip_experiments` is set.**
+
+Invoke the `/ai-scientist-experiment` skill. This is the only stage that requires external API keys because it runs parallel LLM-driven code generation via the BFTS engine.
+
+Before running, verify API keys are set:
 ```bash
-cd /home/user/AI-Scientist-v2
-
-export AI_SCIENTIST_ROOT=/home/user/AI-Scientist-v2
-
-python launch_scientist_bfts.py \
-  --load_ideas "$0" \
-  [pass through all other flags from $ARGUMENTS]
+echo "OPENAI_API_KEY: ${OPENAI_API_KEY:+set}"
+echo "AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:+set}"
 ```
 
-**Important notes:**
-- This is a **long-running process** (typically several hours). Run it in the background using `run_in_background: true` on the Bash tool.
-- Monitor progress by tailing log files in the `experiments/` directory.
-- The process uses significant GPU resources.
+If keys are missing, warn the user and ask whether to skip experiments or stop.
 
-## Output
+Wait for experiments to complete before proceeding.
 
-Results are saved to `experiments/{timestamp}_{idea_name}_attempt_{id}/` containing:
-- `idea.md` / `idea.json` — The research idea
-- `logs/` — Experiment logs and tree visualization
-- `figures/` — Publication-ready plots
-- `*.pdf` — Generated paper (if writeup enabled)
-- `review_text.txt` — LLM review (if review enabled)
-- `review_img_cap_ref.json` — Figure review (if review enabled)
-- `token_tracker.json` — API cost tracking
+### Stage 3: Paper Writeup (Claude Code Native — No API Keys)
 
-After the run completes, report the output directory and key results to the user.
+**Skipped if `--skip_writeup` is set.**
 
-## Error Handling
+Invoke the `/ai-scientist-writeup` skill. Claude Code will:
+1. Read all experiment results and summaries
+2. Search the web for relevant citations
+3. Generate a complete LaTeX paper
+4. Compile to PDF
 
-- If the process fails, check logs in `experiments/*/logs/` for details.
-- Common issues: missing API keys, CUDA out of memory, LaTeX compilation failures.
-- The writeup step retries up to 3 times automatically.
+### Stage 4: Peer Review (Claude Code Native — No API Keys)
+
+**Skipped if `--skip_review` or `--skip_writeup` is set.**
+
+Invoke the `/ai-scientist-review` skill. Claude Code will:
+1. Read the generated PDF
+2. Perform structured peer review (NeurIPS format)
+3. Review figures and captions
+4. Save review results
+
+## Output Summary
+
+After the pipeline completes, report:
+1. Number of ideas generated (if ideation ran)
+2. Experiment results directory
+3. Paper PDF path (if writeup ran)
+4. Review scores and decision (if review ran)
+5. Total pipeline status
+
+## Pipeline Flexibility
+
+The pipeline is modular — users can run any combination:
+
+```
+# Full pipeline from topic
+/ai-scientist my_topic.md
+
+# Ideas exist, run everything
+/ai-scientist ideas.json --idea_idx 0
+
+# Experiments done, just write paper and review
+/ai-scientist ideas.json --skip_experiments --idea_idx 0
+
+# Just review an existing paper
+/ai-scientist-review experiments/my_experiment/
+```

--- a/.claude/skills/ai-scientist/SKILL.md
+++ b/.claude/skills/ai-scientist/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: ai-scientist
-description: Run the full AI Scientist v2 pipeline — ideation through review. Only the experiment stage requires API keys.
+description: Run the full AI Scientist v2 pipeline — autonomous scientific research from ideation through review. No external API keys required (uses Claude Code natively).
 disable-model-invocation: true
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
 argument-hint: <ideas-json-or-topic-md> [--idea_idx N] [--writeup-type normal|icbinb] [--skip_writeup] [--skip_review] [--skip_experiments]
+effort: max
 ---
 
-# AI Scientist v2 — Full Pipeline
+# AI Scientist v2 — Full Pipeline (Claude Code Native)
 
-Orchestrate the complete AI Scientist v2 research pipeline. Stages that previously required API keys (ideation, writeup, review) now run natively in Claude Code. Only the experiment stage still requires external API keys.
+Orchestrate the complete AI Scientist v2 research pipeline. **All stages run natively in Claude Code — no external API keys required** (only `S2_API_KEY` for Semantic Scholar is recommended).
 
 ## Arguments
 
@@ -26,43 +27,55 @@ Parse `$ARGUMENTS`:
 - `--skip_review`: Skip peer review
 - `--max-num-generations N`: Ideas to generate if running ideation (default: 5)
 
+## Environment Check
+
+Before starting, verify:
+```bash
+# Check for Semantic Scholar key (recommended for ideation & writeup)
+echo "S2_API_KEY: ${S2_API_KEY:+set}"
+
+# Check GPU availability (needed for experiments)
+python -c "import torch; print(f'CUDA: {torch.cuda.is_available()}, GPUs: {torch.cuda.device_count()}')" 2>/dev/null || echo "PyTorch not available"
+
+# Check LaTeX (needed for writeup)
+which pdflatex 2>/dev/null && echo "pdflatex: available" || echo "pdflatex: not found (needed for writeup)"
+```
+
+If `S2_API_KEY` is not set, inform the user that literature search will use WebSearch as fallback.
+
 ## Pipeline Stages
 
-### Stage 1: Ideation (Claude Code Native — No API Keys)
+### Stage 1: Ideation (Claude Code Native)
 
 **Only runs if a `.md` file is provided instead of `.json`.**
 
-Invoke the `/ai-scientist-ideate` skill with the topic file. This uses Claude Code's own capabilities and web search for literature review.
+Invoke the `/ai-scientist-ideate` skill with the topic file. This generates structured research ideas using Claude Code's capabilities and Semantic Scholar for literature search.
 
-After ideation, the JSON file path becomes the input for subsequent stages.
+After ideation completes, the JSON file path becomes input for subsequent stages.
 
-### Stage 2: Experiments (Requires API Keys)
+### Stage 2: Experiments (Claude Code Native)
 
 **Skipped if `--skip_experiments` is set.**
 
-Invoke the `/ai-scientist-experiment` skill. This is the only stage that requires external API keys because it runs parallel LLM-driven code generation via the BFTS engine.
+Invoke the `/ai-scientist-experiment` skill. Claude Code acts as both the code generator and analyzer, running the full 4-stage experiment process:
+1. Initial implementation
+2. Hyperparameter tuning
+3. Creative research improvements
+4. Ablation studies
 
-Before running, verify API keys are set:
-```bash
-echo "OPENAI_API_KEY: ${OPENAI_API_KEY:+set}"
-echo "AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:+set}"
-```
+This stage generates code, executes it, analyzes results, views plots, and iterates — all within Claude Code.
 
-If keys are missing, warn the user and ask whether to skip experiments or stop.
-
-Wait for experiments to complete before proceeding.
-
-### Stage 3: Paper Writeup (Claude Code Native — No API Keys)
+### Stage 3: Paper Writeup (Claude Code Native)
 
 **Skipped if `--skip_writeup` is set.**
 
 Invoke the `/ai-scientist-writeup` skill. Claude Code will:
 1. Read all experiment results and summaries
-2. Search the web for relevant citations
+2. Search Semantic Scholar for relevant citations
 3. Generate a complete LaTeX paper
 4. Compile to PDF
 
-### Stage 4: Peer Review (Claude Code Native — No API Keys)
+### Stage 4: Peer Review (Claude Code Native)
 
 **Skipped if `--skip_review` or `--skip_writeup` is set.**
 
@@ -76,7 +89,7 @@ Invoke the `/ai-scientist-review` skill. Claude Code will:
 
 After the pipeline completes, report:
 1. Number of ideas generated (if ideation ran)
-2. Experiment results directory
+2. Experiment results directory and key metrics per stage
 3. Paper PDF path (if writeup ran)
 4. Review scores and decision (if review ran)
 5. Total pipeline status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,32 +4,35 @@ Fully autonomous scientific research system that generates ideas, runs experimen
 
 ## Claude Skills
 
-This project includes Claude Code skills for orchestrating the pipeline. Most stages run **natively in Claude Code** with no API keys — only the experiment stage requires external API keys.
+This project includes Claude Code skills for orchestrating the entire pipeline. **All stages run natively in Claude Code — no external LLM API keys required.** Only `S2_API_KEY` (Semantic Scholar) is recommended for better literature search.
 
-| Skill | Command | API Keys? | Description |
-|-------|---------|-----------|-------------|
-| `/ai-scientist-ideate` | `/ai-scientist-ideate ai_scientist/ideas/topic.md` | No | Generate research ideas using Claude + web search |
-| `/ai-scientist-experiment` | `/ai-scientist-experiment ai_scientist/ideas/topic.json` | **Yes** | Run BFTS experiments (parallel LLM code generation) |
-| `/ai-scientist-writeup` | `/ai-scientist-writeup experiments/dir/` | No | Generate LaTeX paper from experiment results |
-| `/ai-scientist-review` | `/ai-scientist-review experiments/dir/` | No | Peer review a generated paper |
-| `/ai-scientist` | `/ai-scientist ai_scientist/ideas/topic.json` | Partial | Run the full pipeline end-to-end |
+| Skill | Command | Description |
+|-------|---------|-------------|
+| `/ai-scientist-ideate` | `/ai-scientist-ideate ai_scientist/ideas/topic.md` | Generate research ideas using Claude + Semantic Scholar |
+| `/ai-scientist-experiment` | `/ai-scientist-experiment ai_scientist/ideas/topic.json` | Run 4-stage experiments (implement → tune → improve → ablate) |
+| `/ai-scientist-writeup` | `/ai-scientist-writeup experiments/dir/` | Generate LaTeX paper from experiment results |
+| `/ai-scientist-review` | `/ai-scientist-review experiments/dir/` | Peer review a generated paper (NeurIPS format) |
+| `/ai-scientist` | `/ai-scientist ai_scientist/ideas/topic.json` | Run the full pipeline end-to-end |
 
 ### API Key Requirements
 
-- **`S2_API_KEY`** — For Semantic Scholar literature search (used by ideation and writeup skills)
-- **No other keys needed** for: ideation, writeup, and review (Claude Code handles LLM tasks directly)
-- **Keys needed only for experiments** (parallel BFTS tree search):
-  - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME` — For Bedrock (experiment coding)
-  - `OPENAI_API_KEY` — For feedback model during experiments
+- **`S2_API_KEY`** — Semantic Scholar API key for literature search (recommended; falls back to web search if absent)
+- **No other API keys required** — Claude Code handles all LLM tasks directly (code generation, analysis, writeup, review)
+
+### Legacy Mode (External API Keys)
+
+The original Python scripts (`launch_scientist_bfts.py`) are still available for running the pipeline with external LLM APIs:
+- `OPENAI_API_KEY` — For OpenAI models (writeup, review, feedback)
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME` — For Bedrock (experiment coding)
 
 ### Typical Workflow
 
 ```
-# 1. Generate ideas from a research topic (no API keys needed)
+# 1. Generate ideas from a research topic
 /ai-scientist-ideate ai_scientist/ideas/my_topic.md --max-num-generations 5
 
-# 2. Run full pipeline on idea #0 (only experiments need API keys)
-/ai-scientist ai_scientist/ideas/my_topic.json --idea_idx 0 --load_code --add_dataset_ref
+# 2. Run full pipeline on idea #0
+/ai-scientist ai_scientist/ideas/my_topic.json --idea_idx 0 --load_code
 
 # Or run stages independently:
 /ai-scientist-experiment ai_scientist/ideas/my_topic.json --idea_idx 0
@@ -42,8 +45,8 @@ This project includes Claude Code skills for orchestrating the pipeline. Most st
 
 ## Key Files
 
-- `launch_scientist_bfts.py` — Main entry point (for experiment stage)
-- `bfts_config.yaml` — Experiment configuration
+- `launch_scientist_bfts.py` — Legacy entry point (requires external API keys)
+- `bfts_config.yaml` — Experiment configuration (for legacy mode)
 - `ai_scientist/ideas/` — Research topic files and generated ideas
 - `experiments/` — Output directory for results
 - `.claude/skills/` — Claude Code skill definitions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,11 +16,11 @@ This project includes Claude Code skills for orchestrating the pipeline. Most st
 
 ### API Key Requirements
 
-- **No keys needed** for: ideation, writeup, and review (Claude Code handles LLM tasks directly)
+- **`S2_API_KEY`** — For Semantic Scholar literature search (used by ideation and writeup skills)
+- **No other keys needed** for: ideation, writeup, and review (Claude Code handles LLM tasks directly)
 - **Keys needed only for experiments** (parallel BFTS tree search):
   - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME` — For Bedrock (experiment coding)
   - `OPENAI_API_KEY` — For feedback model during experiments
-- **Optional**: `S2_API_KEY` — For Semantic Scholar (ideation uses web search as fallback)
 
 ### Typical Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# AI Scientist v2
+
+Fully autonomous scientific research system that generates ideas, runs experiments via best-first tree search, writes papers, and performs peer review.
+
+## Claude Skills
+
+This project includes Claude Code skills for orchestrating the pipeline:
+
+| Skill | Command | Description |
+|-------|---------|-------------|
+| `/ai-scientist-ideate` | `/ai-scientist-ideate ai_scientist/ideas/topic.md` | Generate research ideas from a topic description |
+| `/ai-scientist-experiment` | `/ai-scientist-experiment ai_scientist/ideas/topic.json` | Run BFTS experiments only |
+| `/ai-scientist-writeup` | `/ai-scientist-writeup experiments/dir/` | Generate paper from completed experiments |
+| `/ai-scientist-review` | `/ai-scientist-review experiments/dir/` | Peer review a generated paper |
+| `/ai-scientist` | `/ai-scientist ai_scientist/ideas/topic.json` | Run the full pipeline end-to-end |
+
+### Typical Workflow
+
+```
+# 1. Generate ideas from a research topic
+/ai-scientist-ideate ai_scientist/ideas/my_topic.md --max-num-generations 10
+
+# 2. Run full pipeline on idea #0
+/ai-scientist ai_scientist/ideas/my_topic.json --idea_idx 0 --load_code --add_dataset_ref
+
+# Or run stages independently:
+/ai-scientist-experiment ai_scientist/ideas/my_topic.json --idea_idx 0
+/ai-scientist-writeup experiments/2025-01-01_my_idea_attempt_0/
+/ai-scientist-review experiments/2025-01-01_my_idea_attempt_0/
+```
+
+## Required Environment Variables
+
+- `OPENAI_API_KEY` — For OpenAI models (writeup, review, feedback)
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME` — For Bedrock (experiment coding)
+- `S2_API_KEY` — For Semantic Scholar literature search (optional)
+
+## Key Files
+
+- `launch_scientist_bfts.py` — Main entry point
+- `bfts_config.yaml` — Experiment configuration
+- `ai_scientist/ideas/` — Research topic files and generated ideas
+- `experiments/` — Output directory for results

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,40 +4,46 @@ Fully autonomous scientific research system that generates ideas, runs experimen
 
 ## Claude Skills
 
-This project includes Claude Code skills for orchestrating the pipeline:
+This project includes Claude Code skills for orchestrating the pipeline. Most stages run **natively in Claude Code** with no API keys — only the experiment stage requires external API keys.
 
-| Skill | Command | Description |
-|-------|---------|-------------|
-| `/ai-scientist-ideate` | `/ai-scientist-ideate ai_scientist/ideas/topic.md` | Generate research ideas from a topic description |
-| `/ai-scientist-experiment` | `/ai-scientist-experiment ai_scientist/ideas/topic.json` | Run BFTS experiments only |
-| `/ai-scientist-writeup` | `/ai-scientist-writeup experiments/dir/` | Generate paper from completed experiments |
-| `/ai-scientist-review` | `/ai-scientist-review experiments/dir/` | Peer review a generated paper |
-| `/ai-scientist` | `/ai-scientist ai_scientist/ideas/topic.json` | Run the full pipeline end-to-end |
+| Skill | Command | API Keys? | Description |
+|-------|---------|-----------|-------------|
+| `/ai-scientist-ideate` | `/ai-scientist-ideate ai_scientist/ideas/topic.md` | No | Generate research ideas using Claude + web search |
+| `/ai-scientist-experiment` | `/ai-scientist-experiment ai_scientist/ideas/topic.json` | **Yes** | Run BFTS experiments (parallel LLM code generation) |
+| `/ai-scientist-writeup` | `/ai-scientist-writeup experiments/dir/` | No | Generate LaTeX paper from experiment results |
+| `/ai-scientist-review` | `/ai-scientist-review experiments/dir/` | No | Peer review a generated paper |
+| `/ai-scientist` | `/ai-scientist ai_scientist/ideas/topic.json` | Partial | Run the full pipeline end-to-end |
+
+### API Key Requirements
+
+- **No keys needed** for: ideation, writeup, and review (Claude Code handles LLM tasks directly)
+- **Keys needed only for experiments** (parallel BFTS tree search):
+  - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME` — For Bedrock (experiment coding)
+  - `OPENAI_API_KEY` — For feedback model during experiments
+- **Optional**: `S2_API_KEY` — For Semantic Scholar (ideation uses web search as fallback)
 
 ### Typical Workflow
 
 ```
-# 1. Generate ideas from a research topic
-/ai-scientist-ideate ai_scientist/ideas/my_topic.md --max-num-generations 10
+# 1. Generate ideas from a research topic (no API keys needed)
+/ai-scientist-ideate ai_scientist/ideas/my_topic.md --max-num-generations 5
 
-# 2. Run full pipeline on idea #0
+# 2. Run full pipeline on idea #0 (only experiments need API keys)
 /ai-scientist ai_scientist/ideas/my_topic.json --idea_idx 0 --load_code --add_dataset_ref
 
 # Or run stages independently:
 /ai-scientist-experiment ai_scientist/ideas/my_topic.json --idea_idx 0
 /ai-scientist-writeup experiments/2025-01-01_my_idea_attempt_0/
 /ai-scientist-review experiments/2025-01-01_my_idea_attempt_0/
+
+# Skip experiments if results already exist:
+/ai-scientist ai_scientist/ideas/my_topic.json --skip_experiments --idea_idx 0
 ```
-
-## Required Environment Variables
-
-- `OPENAI_API_KEY` — For OpenAI models (writeup, review, feedback)
-- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION_NAME` — For Bedrock (experiment coding)
-- `S2_API_KEY` — For Semantic Scholar literature search (optional)
 
 ## Key Files
 
-- `launch_scientist_bfts.py` — Main entry point
+- `launch_scientist_bfts.py` — Main entry point (for experiment stage)
 - `bfts_config.yaml` — Experiment configuration
 - `ai_scientist/ideas/` — Research topic files and generated ideas
 - `experiments/` — Output directory for results
+- `.claude/skills/` — Claude Code skill definitions

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "ai-scientist",
+  "version": "1.0.0",
+  "description": "Fully autonomous scientific research pipeline — generate ideas, run experiments, write papers, and peer review. All stages run natively in Claude Code with no external LLM API keys.",
+  "author": {
+    "name": "Sakana AI",
+    "url": "https://github.com/SakanaAI/AI-Scientist-v2"
+  },
+  "repository": "https://github.com/strelkon/AI-Scientist-v2",
+  "license": "Apache-2.0",
+  "keywords": [
+    "research",
+    "science",
+    "ml",
+    "experiments",
+    "paper-writing",
+    "peer-review",
+    "latex",
+    "semantic-scholar"
+  ],
+  "userConfig": {
+    "S2_API_KEY": {
+      "description": "Semantic Scholar API key for literature search (recommended). Get one at https://www.semanticscholar.org/product/api",
+      "required": false,
+      "env": "S2_API_KEY"
+    },
+    "PROJECT_DIR": {
+      "description": "Path to the AI-Scientist-v2 repository checkout (with ai_scientist/ and bfts_config.yaml)",
+      "required": true,
+      "env": "AI_SCIENTIST_ROOT"
+    }
+  }
+}

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -20,14 +20,16 @@
   ],
   "userConfig": {
     "S2_API_KEY": {
-      "description": "Semantic Scholar API key for literature search (recommended). Get one at https://www.semanticscholar.org/product/api",
-      "required": false,
-      "env": "S2_API_KEY"
+      "title": "Semantic Scholar API Key",
+      "description": "API key for literature search (recommended). Get one at https://www.semanticscholar.org/product/api",
+      "type": "string",
+      "required": false
     },
     "PROJECT_DIR": {
+      "title": "AI-Scientist-v2 Repository Path",
       "description": "Path to the AI-Scientist-v2 repository checkout (with ai_scientist/ and bfts_config.yaml)",
-      "required": true,
-      "env": "AI_SCIENTIST_ROOT"
+      "type": "directory",
+      "required": true
     }
   }
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,69 @@
+# AI Scientist v2 — Claude Code Plugin
+
+A Claude Code / Claude Co-Work plugin for autonomous scientific research. Generates ideas, runs ML experiments, writes LaTeX papers, and performs peer review — all natively within Claude Code.
+
+## Installation
+
+### From GitHub
+
+```
+/plugin marketplace add strelkon/AI-Scientist-v2
+/plugin install ai-scientist@strelkon-AI-Scientist-v2
+```
+
+### From Local Path (development)
+
+```bash
+claude --plugin-dir ./plugin
+```
+
+## Setup
+
+When you install the plugin, you'll be prompted for:
+
+1. **`PROJECT_DIR`** (required): Path to your AI-Scientist-v2 repository checkout
+2. **`S2_API_KEY`** (recommended): Semantic Scholar API key for literature search — get one at https://www.semanticscholar.org/product/api
+
+### System Requirements
+
+- Python 3.10+ with PyTorch (CUDA recommended)
+- LaTeX (`pdflatex`, `bibtex`, `chktex`) for paper generation
+- Project dependencies: `pip install -r requirements.txt`
+
+## Skills
+
+| Skill | Command | Description |
+|-------|---------|-------------|
+| **pipeline** | `/ai-scientist:pipeline topic.md` | Full end-to-end pipeline |
+| **ideate** | `/ai-scientist:ideate topic.md` | Generate research ideas |
+| **experiment** | `/ai-scientist:experiment ideas.json` | Run 4-stage experiments |
+| **writeup** | `/ai-scientist:writeup experiments/dir/` | Generate LaTeX paper |
+| **review** | `/ai-scientist:review experiments/dir/` | NeurIPS-format peer review |
+
+## Usage
+
+```bash
+# Generate ideas from a research topic
+/ai-scientist:ideate ai_scientist/ideas/my_topic.md --max-num-generations 5
+
+# Run full pipeline on idea #0
+/ai-scientist:pipeline ai_scientist/ideas/my_topic.json --idea_idx 0
+
+# Run stages independently
+/ai-scientist:experiment ai_scientist/ideas/my_topic.json --idea_idx 0
+/ai-scientist:writeup experiments/2025-01-01_my_idea_attempt_0/
+/ai-scientist:review experiments/2025-01-01_my_idea_attempt_0/
+
+# Skip experiments if results already exist
+/ai-scientist:pipeline ideas.json --skip_experiments --idea_idx 0
+```
+
+## API Keys
+
+- **No external LLM API keys required** — Claude Code handles all LLM tasks
+- **`S2_API_KEY`** recommended for Semantic Scholar (falls back to web search)
+- The original Python scripts (`launch_scientist_bfts.py`) remain available as legacy mode if you prefer using external LLM APIs
+
+## License
+
+Apache-2.0 (same as AI-Scientist-v2)

--- a/plugin/skills/experiment/SKILL.md
+++ b/plugin/skills/experiment/SKILL.md
@@ -13,9 +13,7 @@ You are an expert ML researcher running experiments through a structured 4-stage
 
 ## Environment
 
-```bash
-echo "AI_SCIENTIST_ROOT: ${AI_SCIENTIST_ROOT:?'ERROR: Set AI_SCIENTIST_ROOT to the AI-Scientist-v2 repo path'}"
-```
+- **PROJECT_DIR**: `${user_config.PROJECT_DIR}` — path to the AI-Scientist-v2 repository.
 
 ## Arguments
 
@@ -29,7 +27,7 @@ echo "AI_SCIENTIST_ROOT: ${AI_SCIENTIST_ROOT:?'ERROR: Set AI_SCIENTIST_ROOT to t
 ### 1a. Load the Research Idea
 
 ```bash
-cd ${AI_SCIENTIST_ROOT}
+cd ${user_config.PROJECT_DIR}
 ```
 
 Read the ideas JSON file and extract the idea at the specified index. Read the idea's fields:
@@ -42,7 +40,7 @@ Read the ideas JSON file and extract the idea at the specified index. Read the i
 ```bash
 DATE=$(date +%Y-%m-%d_%H-%M-%S)
 IDEA_NAME="<idea Name field>"
-EXPERIMENT_DIR="${AI_SCIENTIST_ROOT}/experiments/${DATE}_${IDEA_NAME}_attempt_0"
+EXPERIMENT_DIR="${user_config.PROJECT_DIR}/experiments/${DATE}_${IDEA_NAME}_attempt_0"
 mkdir -p "$EXPERIMENT_DIR/logs/0-run"
 mkdir -p "$EXPERIMENT_DIR/figures"
 ```

--- a/plugin/skills/experiment/SKILL.md
+++ b/plugin/skills/experiment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: experiment
 description: Run AI Scientist v2 experiments using Claude Code as the code generator — no external API keys required. Implements the 4-stage BFTS workflow natively.
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent
 argument-hint: <ideas-json-path> [--idea_idx N] [--load_code] [--add_dataset_ref]
 effort: max

--- a/plugin/skills/experiment/SKILL.md
+++ b/plugin/skills/experiment/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: experiment
+description: Run AI Scientist v2 experiments using Claude Code as the code generator — no external API keys required. Implements the 4-stage BFTS workflow natively.
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent
+argument-hint: <ideas-json-path> [--idea_idx N] [--load_code] [--add_dataset_ref]
+effort: max
+---
+
+# AI Scientist v2 — Experiment Execution (Claude Code Native)
+
+You are an expert ML researcher running experiments through a structured 4-stage process. You will generate Python code, execute it, analyze results, debug failures, and iteratively improve — all within Claude Code. **No external API keys required.**
+
+## Environment
+
+```bash
+echo "AI_SCIENTIST_ROOT: ${AI_SCIENTIST_ROOT:?'ERROR: Set AI_SCIENTIST_ROOT to the AI-Scientist-v2 repo path'}"
+```
+
+## Arguments
+
+- **Positional arg 1** (`$ARGUMENTS` first word): Path to ideas JSON file (required)
+- `--idea_idx N`: Which idea to run (default: 0)
+- `--load_code`: Load companion `.py` starter code file
+- `--add_dataset_ref`: Include HuggingFace dataset reference code
+
+## Step 1: Setup
+
+### 1a. Load the Research Idea
+
+```bash
+cd ${AI_SCIENTIST_ROOT}
+```
+
+Read the ideas JSON file and extract the idea at the specified index. Read the idea's fields:
+- **Name**, **Title**, **Short Hypothesis**
+- **Abstract**, **Experiments** (specific experiment plans)
+- **Code** (if `--load_code` was used and code exists)
+
+### 1b. Create Experiment Directory
+
+```bash
+DATE=$(date +%Y-%m-%d_%H-%M-%S)
+IDEA_NAME="<idea Name field>"
+EXPERIMENT_DIR="${AI_SCIENTIST_ROOT}/experiments/${DATE}_${IDEA_NAME}_attempt_0"
+mkdir -p "$EXPERIMENT_DIR/logs/0-run"
+mkdir -p "$EXPERIMENT_DIR/figures"
+```
+
+Save the idea as `idea.md` and `idea.json` in the experiment directory.
+
+### 1c. Define Evaluation Metrics
+
+Based on the research idea and experiments described, define ONE primary evaluation metric:
+- **metric_name**: Precise name (e.g., "validation accuracy", "test BLEU score")
+- **lower_is_better**: Whether lower values are better (true for loss, false for accuracy)
+- **description**: What this metric measures
+
+Validation loss is always tracked separately in addition to the primary metric.
+
+## Step 2: Stage 1 — Initial Implementation
+
+**Goal**: Get a basic working implementation of the research idea.
+
+### Code Generation Requirements
+
+All generated experiment code MUST follow these conventions:
+
+```python
+import os
+import numpy as np
+import torch
+
+# GPU setup
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+print(f'Using device: {device}')
+
+# Working directory
+working_dir = os.path.join(os.getcwd(), 'working')
+os.makedirs(working_dir, exist_ok=True)
+
+# ... experiment code ...
+
+# Save results in standard format
+experiment_data = {
+    'dataset_name_1': {
+        'metrics': {'train': [epoch1_val, epoch2_val, ...], 'val': [...]},
+        'losses': {'train': [...], 'val': [...]},
+        'predictions': [...],  # optional
+        'ground_truth': [...]  # optional
+    }
+}
+np.save(os.path.join(working_dir, 'experiment_data.npy'), experiment_data)
+print(f'Results saved to {os.path.join(working_dir, "experiment_data.npy")}')
+```
+
+**Rules:**
+- ALL code at global scope — NO `if __name__ == "__main__"` blocks
+- Move models and data to `device` using `.to(device)`
+- Use try-except for robustness
+- Print metrics clearly: `print(f'Dataset: {name}, {metric}: {value:.4f}')`
+- Keep execution under 60 minutes
+- Start with ONE simple dataset, use standard HuggingFace datasets when possible
+
+### Iteration Loop (up to 5 attempts)
+
+For each attempt:
+
+1. **Generate code**: Write a complete Python script implementing the baseline approach described in the idea
+2. **Save and execute**:
+   ```bash
+   cd $EXPERIMENT_DIR
+   mkdir -p workspace/working
+   # Write the code to workspace/runfile.py using the Write tool
+   cd workspace && timeout 3600 python runfile.py 2>&1 | tee execution_output.txt
+   ```
+3. **Analyze results**:
+   - Check if `workspace/working/experiment_data.npy` was created
+   - Read execution output for errors or metrics
+   - If the code errored: **debug** — analyze the error, fix the code, retry
+   - If the code succeeded: **evaluate** — check if metrics are reasonable
+4. **If successful**: Move to plotting, then Stage 2
+5. **If failed after 5 attempts**: Report failure and stop
+
+### Generate Plots
+
+After a successful run, generate a plotting script:
+
+```python
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import os
+
+working_dir = os.path.join(os.getcwd(), 'working')
+data = np.load(os.path.join(working_dir, 'experiment_data.npy'), allow_pickle=True).item()
+
+figures_dir = os.path.join(os.getcwd(), '..', 'figures')
+os.makedirs(figures_dir, exist_ok=True)
+
+for dataset_name, dataset_data in data.items():
+    try:
+        if 'losses' in dataset_data:
+            fig, ax = plt.subplots(figsize=(8, 6))
+            # ... plot training/validation loss curves
+            plt.savefig(os.path.join(figures_dir, f'{dataset_name}_training_curves.png'), dpi=300, bbox_inches='tight')
+            plt.close()
+        if 'metrics' in dataset_data:
+            fig, ax = plt.subplots(figsize=(8, 6))
+            # ... plot metric curves
+            plt.savefig(os.path.join(figures_dir, f'{dataset_name}_metrics.png'), dpi=300, bbox_inches='tight')
+            plt.close()
+    except Exception as e:
+        print(f'Error plotting {dataset_name}: {e}')
+```
+
+Execute the plotting script. Then **view the generated plots** using the Read tool to verify they look correct.
+
+### Save Stage 1 Summary
+
+After Stage 1, save a summary to `$EXPERIMENT_DIR/logs/0-run/baseline_summary.json`:
+
+```json
+{
+  "best_node": {
+    "overall_plan": "<description of approach>",
+    "analysis": "<analysis of results>",
+    "metric": "<primary metric value>",
+    "code": "<the working Python code>",
+    "plot_code": "<the plotting code>",
+    "plot_analyses": ["<description of each plot>"],
+    "vlm_feedback_summary": "<summary of what plots show>",
+    "exp_results_npy_files": ["experiment_results/stage1/experiment_data.npy"],
+    "datasets_successfully_tested": ["dataset_name_1"]
+  }
+}
+```
+
+Copy experiment data:
+```bash
+mkdir -p $EXPERIMENT_DIR/logs/0-run/experiment_results/stage1
+cp $EXPERIMENT_DIR/workspace/working/experiment_data.npy $EXPERIMENT_DIR/logs/0-run/experiment_results/stage1/
+```
+
+## Step 3: Stage 2 — Baseline Tuning
+
+**Goal**: Optimize hyperparameters of the Stage 1 implementation. DO NOT change model architecture. Introduce ONE additional dataset (total: 2 datasets).
+
+### Iteration Loop (up to 4 attempts)
+
+For each attempt, pick ONE hyperparameter to tune:
+1. Training longer (more epochs)
+2. Learning rate adjustment
+3. Batch size optimization
+4. Regularization (dropout, weight decay)
+5. Other algorithm-specific parameters
+
+For each:
+1. Take the best Stage 1 code as base
+2. Modify the specific hyperparameter
+3. Add a second dataset
+4. Execute and analyze results
+5. Compare metrics with Stage 1 baseline
+6. View generated plots to assess convergence
+
+### Save Stage 2 Summary
+
+Save to `$EXPERIMENT_DIR/logs/0-run/baseline_summary.json` (update the existing file to include tuning results).
+
+Copy results:
+```bash
+mkdir -p $EXPERIMENT_DIR/logs/0-run/experiment_results/stage2
+cp $EXPERIMENT_DIR/workspace/working/experiment_data.npy $EXPERIMENT_DIR/logs/0-run/experiment_results/stage2/
+```
+
+## Step 4: Stage 3 — Creative Research
+
+**Goal**: Explore novel improvements to the approach. Be creative. Use THREE HuggingFace datasets total.
+
+### Iteration Loop (up to 4 attempts)
+
+For each attempt:
+1. Start from the best Stage 2 code
+2. Propose a **novel improvement** inspired by the research idea
+3. Add a third dataset
+4. Execute and compare with previous stages
+5. View plots to verify improvements
+
+### Save Stage 3 Summary
+
+Save to `$EXPERIMENT_DIR/logs/0-run/research_summary.json`.
+
+Copy results:
+```bash
+mkdir -p $EXPERIMENT_DIR/logs/0-run/experiment_results/stage3
+cp $EXPERIMENT_DIR/workspace/working/experiment_data.npy $EXPERIMENT_DIR/logs/0-run/experiment_results/stage3/
+```
+
+## Step 5: Stage 4 — Ablation Studies
+
+**Goal**: Conduct systematic component analysis. Use the same datasets from Stage 3.
+
+### Iteration Loop (3-5 ablations)
+
+For each ablation:
+1. Start from the best Stage 3 code
+2. **Remove or disable ONE specific component** to measure its contribution
+3. Execute with the same 3 datasets
+4. Compare with full Stage 3 model
+5. Record the performance delta
+
+### Save Stage 4 Summary
+
+Save to `$EXPERIMENT_DIR/logs/0-run/ablation_summary.json`.
+
+Copy results per ablation:
+```bash
+mkdir -p $EXPERIMENT_DIR/logs/0-run/experiment_results/stage4_ablation1
+cp $EXPERIMENT_DIR/workspace/working/experiment_data.npy $EXPERIMENT_DIR/logs/0-run/experiment_results/stage4_ablation1/
+```
+
+## Step 6: Plot Aggregation
+
+Create a comprehensive plot aggregation script. Save up to 12 figures in `$EXPERIMENT_DIR/figures/`. Save the script as `$EXPERIMENT_DIR/auto_plot_aggregator.py`.
+
+Guidelines: DPI 300, remove top/right spines, clear labels (no underscores), each plot in try-except, combine related plots (up to 3 subplots per figure).
+
+## Step 7: Report Results
+
+Summarize for the user:
+1. **Stage 1-4 Results** with key metrics
+2. **Output directory** path
+3. **Next step**: Run `/ai-scientist:writeup $EXPERIMENT_DIR` to generate a paper
+
+## Error Handling
+
+- If a stage completely fails, log and proceed with best available code
+- Fall back to CPU if no GPU available
+- Never spend more than 5 attempts debugging the same error
+
+## Parallelism with Agent Tool
+
+For Stage 4 ablations, you MAY use the **Agent tool** to run multiple ablations in parallel.

--- a/plugin/skills/ideate/SKILL.md
+++ b/plugin/skills/ideate/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: ideate
+description: Generate research ideas for AI Scientist v2 — uses Claude Code directly with Semantic Scholar for literature search
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
+argument-hint: <workshop-topic-file.md> [--max-num-generations N] [--num-reflections N]
+---
+
+# AI Scientist v2 — Idea Generation (Claude Code Native)
+
+You are an experienced AI researcher generating high-impact research ideas. This skill runs within Claude Code using Semantic Scholar for literature search.
+
+## Environment
+
+- **AI_SCIENTIST_ROOT**: `${AI_SCIENTIST_ROOT}` — path to the AI-Scientist-v2 repository.
+- **S2_API_KEY**: Recommended for Semantic Scholar API access. Verify:
+  ```bash
+  echo "AI_SCIENTIST_ROOT: ${AI_SCIENTIST_ROOT:?'ERROR: Set AI_SCIENTIST_ROOT to the AI-Scientist-v2 repo path'}"
+  echo "S2_API_KEY: ${S2_API_KEY:+set}"
+  ```
+  If `S2_API_KEY` is not set, warn the user and fall back to WebSearch.
+
+## Arguments
+
+- **Positional arg 1** (`$ARGUMENTS` first word): Path to workshop topic markdown file
+- `--max-num-generations N`: Number of ideas to generate (default: 5)
+- `--num-reflections N`: Refinement rounds per idea (default: 3)
+
+If no file is provided, ask the user for a research topic.
+
+## Step 1: Load the Workshop Topic
+
+Read the workshop topic markdown file. It should contain:
+- Title
+- Keywords
+- TL;DR
+- Abstract describing the research area
+
+If the user provides a topic description but no file exists, create one at `${AI_SCIENTIST_ROOT}/ai_scientist/ideas/<topic_name>.md` with this structure:
+
+```markdown
+# Title: <Workshop/Topic Title>
+
+## Keywords
+keyword1, keyword2, keyword3
+
+## TL;DR
+<One-sentence summary>
+
+## Abstract
+<Detailed description ~250 words>
+```
+
+## Step 2: Generate Ideas Iteratively
+
+For each idea (up to max-num-generations), follow this process:
+
+### 2a. Literature Search
+
+Use **Semantic Scholar** to find relevant papers. Run searches via the existing Python tool:
+
+```bash
+cd ${AI_SCIENTIST_ROOT}
+python -c "
+from ai_scientist.tools.semantic_scholar import SemanticScholarSearchTool
+tool = SemanticScholarSearchTool(max_results=10)
+result = tool.use_tool('YOUR SEARCH QUERY HERE')
+print(result)
+"
+```
+
+For each idea, perform at least 2-3 searches to ground it in existing literature:
+- The main topic keywords
+- Specific sub-areas relevant to the idea you're developing
+- Recent advances and open problems
+
+If Semantic Scholar is unavailable (no API key or rate limited), fall back to **WebSearch**.
+
+### 2b. Idea Generation
+
+As an experienced AI researcher, generate a research idea that:
+- Stems from a simple, elegant question or hypothesis
+- Is clearly novel and distinct from existing literature
+- Is feasible for an academic lab (no massive compute requirements)
+- Would be publishable at a top ML conference
+- Includes specific, testable experiments
+
+### 2c. Reflection & Refinement
+
+For each reflection round:
+1. Critically evaluate your idea for quality, novelty, and feasibility
+2. Search for additional related work if needed
+3. Refine the hypothesis, experiments, and framing
+4. Ensure the idea isn't a trivial extension of existing work
+
+### 2d. Finalize Each Idea
+
+Each idea must be a JSON object with exactly these fields:
+
+```json
+{
+  "Name": "lowercase_with_underscores",
+  "Title": "Catchy and informative title",
+  "Short Hypothesis": "Concise statement of the main hypothesis. Clarify the need for this direction and why it's the best setting to investigate.",
+  "Related Work": "Discussion of relevant related work and how this proposal distinguishes from it.",
+  "Abstract": "Conference-format abstract, approximately 250 words.",
+  "Experiments": [
+    "Experiment 1: Specific description with metrics...",
+    "Experiment 2: ..."
+  ],
+  "Risk Factors and Limitations": [
+    "Risk 1: ...",
+    "Risk 2: ..."
+  ]
+}
+```
+
+**Important**: Each new idea should be distinct from all previously generated ideas. Avoid duplicating themes or approaches.
+
+## Step 3: Save Output
+
+Save all ideas as a JSON array to a file alongside the input markdown file with the same base name but `.json` extension.
+
+For example: `ai_scientist/ideas/my_topic.md` → `ai_scientist/ideas/my_topic.json`
+
+Write the file using the Write tool.
+
+## Step 4: Report Results
+
+After generating all ideas, list them with:
+- Index number
+- Title
+- One-line hypothesis summary
+
+Tell the user they can run experiments with:
+```
+/ai-scientist:experiment <path-to-ideas.json> --idea_idx <N>
+```
+
+## Guidelines
+
+- Be very creative and think out of the box
+- Each proposal should stem from a simple and elegant question
+- Proposals should explore new possibilities or challenge existing assumptions
+- Ensure feasibility — no resources beyond what an academic lab could afford
+- Perform literature searches to ensure novelty
+- Keep experiments specific: detail exact algorithmic changes and evaluation metrics

--- a/plugin/skills/ideate/SKILL.md
+++ b/plugin/skills/ideate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ideate
 description: Generate research ideas for AI Scientist v2 — uses Claude Code directly with Semantic Scholar for literature search
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
 argument-hint: <workshop-topic-file.md> [--max-num-generations N] [--num-reflections N]
 ---

--- a/plugin/skills/ideate/SKILL.md
+++ b/plugin/skills/ideate/SKILL.md
@@ -12,13 +12,9 @@ You are an experienced AI researcher generating high-impact research ideas. This
 
 ## Environment
 
-- **AI_SCIENTIST_ROOT**: `${AI_SCIENTIST_ROOT}` — path to the AI-Scientist-v2 repository.
-- **S2_API_KEY**: Recommended for Semantic Scholar API access. Verify:
-  ```bash
-  echo "AI_SCIENTIST_ROOT: ${AI_SCIENTIST_ROOT:?'ERROR: Set AI_SCIENTIST_ROOT to the AI-Scientist-v2 repo path'}"
-  echo "S2_API_KEY: ${S2_API_KEY:+set}"
-  ```
-  If `S2_API_KEY` is not set, warn the user and fall back to WebSearch.
+- **PROJECT_DIR**: `${user_config.PROJECT_DIR}` — path to the AI-Scientist-v2 repository.
+- **S2_API_KEY**: `${user_config.S2_API_KEY}` — recommended for Semantic Scholar API access.
+  If not configured, warn the user and fall back to WebSearch.
 
 ## Arguments
 
@@ -36,7 +32,7 @@ Read the workshop topic markdown file. It should contain:
 - TL;DR
 - Abstract describing the research area
 
-If the user provides a topic description but no file exists, create one at `${AI_SCIENTIST_ROOT}/ai_scientist/ideas/<topic_name>.md` with this structure:
+If the user provides a topic description but no file exists, create one at `${user_config.PROJECT_DIR}/ai_scientist/ideas/<topic_name>.md` with this structure:
 
 ```markdown
 # Title: <Workshop/Topic Title>
@@ -60,8 +56,8 @@ For each idea (up to max-num-generations), follow this process:
 Use **Semantic Scholar** to find relevant papers. Run searches via the existing Python tool:
 
 ```bash
-cd ${AI_SCIENTIST_ROOT}
-python -c "
+cd ${user_config.PROJECT_DIR}
+S2_API_KEY="${user_config.S2_API_KEY}" python -c "
 from ai_scientist.tools.semantic_scholar import SemanticScholarSearchTool
 tool = SemanticScholarSearchTool(max_results=10)
 result = tool.use_tool('YOUR SEARCH QUERY HERE')

--- a/plugin/skills/pipeline/SKILL.md
+++ b/plugin/skills/pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pipeline
 description: Run the full AI Scientist v2 pipeline — autonomous scientific research from ideation through review. No external API keys required.
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
 argument-hint: <ideas-json-or-topic-md> [--idea_idx N] [--writeup-type normal|icbinb] [--skip_writeup] [--skip_review] [--skip_experiments]
 effort: max

--- a/plugin/skills/pipeline/SKILL.md
+++ b/plugin/skills/pipeline/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: pipeline
+description: Run the full AI Scientist v2 pipeline — autonomous scientific research from ideation through review. No external API keys required.
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
+argument-hint: <ideas-json-or-topic-md> [--idea_idx N] [--writeup-type normal|icbinb] [--skip_writeup] [--skip_review] [--skip_experiments]
+effort: max
+---
+
+# AI Scientist v2 — Full Pipeline (Claude Code Native)
+
+Orchestrate the complete AI Scientist v2 research pipeline. **All stages run natively in Claude Code** — only `S2_API_KEY` for Semantic Scholar is recommended.
+
+## Environment
+
+```bash
+echo "AI_SCIENTIST_ROOT: ${AI_SCIENTIST_ROOT:?'ERROR: Set AI_SCIENTIST_ROOT to the AI-Scientist-v2 repo path'}"
+echo "S2_API_KEY: ${S2_API_KEY:+set}"
+python -c "import torch; print(f'CUDA: {torch.cuda.is_available()}, GPUs: {torch.cuda.device_count()}')" 2>/dev/null || echo "PyTorch not available"
+which pdflatex 2>/dev/null && echo "pdflatex: available" || echo "pdflatex: not found (needed for writeup)"
+```
+
+## Arguments
+
+- **Positional arg 1**: Path to `.json` (ideas, skips ideation) or `.md` (topic, runs ideation first)
+- `--idea_idx N`: Which idea (default: 0)
+- `--writeup-type TYPE`: `icbinb` (4-page, default) or `normal` (8-page)
+- `--load_code`: Load companion .py starter code
+- `--add_dataset_ref`: Add HuggingFace dataset reference
+- `--skip_experiments`: Skip experiment execution
+- `--skip_writeup`: Skip paper generation
+- `--skip_review`: Skip peer review
+- `--max-num-generations N`: Ideas to generate (default: 5)
+
+## Pipeline Stages
+
+### Stage 1: Ideation (if `.md` input)
+
+Invoke `/ai-scientist:ideate` with the topic file.
+
+### Stage 2: Experiments
+
+**Skipped if `--skip_experiments`.**
+
+Invoke `/ai-scientist:experiment`. Runs the full 4-stage process:
+1. Initial implementation
+2. Hyperparameter tuning
+3. Creative research improvements
+4. Ablation studies
+
+### Stage 3: Paper Writeup
+
+**Skipped if `--skip_writeup`.**
+
+Invoke `/ai-scientist:writeup`. Generates LaTeX paper with Semantic Scholar citations.
+
+### Stage 4: Peer Review
+
+**Skipped if `--skip_review` or `--skip_writeup`.**
+
+Invoke `/ai-scientist:review`. NeurIPS-format structured review.
+
+## Output Summary
+
+Report: ideas generated, experiment directory + metrics, PDF path, review scores.
+
+## Examples
+
+```
+# Full pipeline from topic
+/ai-scientist:pipeline my_topic.md
+
+# Ideas exist, run everything
+/ai-scientist:pipeline ideas.json --idea_idx 0
+
+# Skip experiments, just write paper and review
+/ai-scientist:pipeline ideas.json --skip_experiments --idea_idx 0
+
+# Individual stages
+/ai-scientist:ideate topic.md
+/ai-scientist:experiment ideas.json --idea_idx 0
+/ai-scientist:writeup experiments/dir/
+/ai-scientist:review experiments/dir/
+```

--- a/plugin/skills/pipeline/SKILL.md
+++ b/plugin/skills/pipeline/SKILL.md
@@ -13,9 +13,11 @@ Orchestrate the complete AI Scientist v2 research pipeline. **All stages run nat
 
 ## Environment
 
+- **PROJECT_DIR**: `${user_config.PROJECT_DIR}` — path to the AI-Scientist-v2 repository.
+- **S2_API_KEY**: `${user_config.S2_API_KEY}` — Semantic Scholar API key (optional).
+
+Before starting, verify system dependencies:
 ```bash
-echo "AI_SCIENTIST_ROOT: ${AI_SCIENTIST_ROOT:?'ERROR: Set AI_SCIENTIST_ROOT to the AI-Scientist-v2 repo path'}"
-echo "S2_API_KEY: ${S2_API_KEY:+set}"
 python -c "import torch; print(f'CUDA: {torch.cuda.is_available()}, GPUs: {torch.cuda.device_count()}')" 2>/dev/null || echo "PyTorch not available"
 which pdflatex 2>/dev/null && echo "pdflatex: available" || echo "pdflatex: not found (needed for writeup)"
 ```

--- a/plugin/skills/review/SKILL.md
+++ b/plugin/skills/review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review
 description: Perform AI peer review of a scientific paper — uses Claude Code directly, no API keys required
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Write, Glob, Grep
 argument-hint: <experiment-dir>
 ---

--- a/plugin/skills/review/SKILL.md
+++ b/plugin/skills/review/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: review
+description: Perform AI peer review of a scientific paper — uses Claude Code directly, no API keys required
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Glob, Grep
+argument-hint: <experiment-dir>
+---
+
+# AI Scientist v2 — Paper Review (Claude Code Native)
+
+You are an expert peer reviewer for a top ML conference (NeurIPS). Review the paper thoroughly and critically. **No API keys required.**
+
+## Arguments
+
+- **Positional arg 1** (`$ARGUMENTS` first word): Path to experiment directory containing the PDF
+
+## Step 1: Find and Load the Paper
+
+```bash
+ls <experiment-dir>/*.pdf
+```
+
+If multiple PDFs exist, prefer:
+1. Files containing "reflection_final" in the name
+2. Files with the highest reflection number
+3. The most recently modified PDF
+
+Convert the PDF to readable text:
+```bash
+pdftotext <pdf-path> -
+```
+
+Also read the PDF directly using the Read tool (it supports PDF files) to see figures.
+
+Read the research idea from `<experiment-dir>/idea.md` or `<experiment-dir>/idea.json` for context.
+
+## Step 2: Text Review
+
+Review the paper following the **NeurIPS review form**:
+
+1. **Summary**: Summarize contributions in 2-3 sentences
+2. **Strengths**: Novelty, soundness, clarity, significance, experiment quality
+3. **Weaknesses**: Missing baselines, questionable methodology, insufficient analysis, overclaims
+4. **Questions**: Questions for the authors
+5. **Limitations**: Whether limitations are adequately discussed
+6. **Scores**:
+   - **Soundness** (1-4): 1=poor, 2=fair, 3=good, 4=excellent
+   - **Presentation** (1-4): 1=poor, 2=fair, 3=good, 4=excellent
+   - **Contribution** (1-4): 1=poor, 2=fair, 3=good, 4=excellent
+   - **Originality** (1-4): 1=low, 2=medium, 3=high, 4=very high
+   - **Quality** (1-4): 1=low, 2=medium, 3=high, 4=very high
+   - **Clarity** (1-4): 1=low, 2=medium, 3=high, 4=very high
+   - **Significance** (1-4): 1=low, 2=medium, 3=high, 4=very high
+   - **Overall** (1-10): 1=very strong reject, 3=clear reject, 5=marginally below, 6=marginally above, 8=clear accept, 10=award quality
+   - **Confidence** (1-5): 1=low, 3=moderate, 5=absolute certainty
+7. **Decision**: "Accept" or "Reject"
+
+### Guidelines
+- Be critical but fair — if unsure, lean toward rejection
+- Check that all claims are supported by evidence
+- Verify figures match the text discussion
+
+## Step 3: Figure Review
+
+Using the Read tool to view the PDF, evaluate each figure for description, quality, caption accuracy, relevance, and suggestions. Check for duplicates, unreferenced figures, missing labels.
+
+## Step 4: Save Review Output
+
+Save text review to `<experiment-dir>/review_text.txt` as JSON:
+```json
+{
+  "Summary": "...", "Strengths": [...], "Weaknesses": [...],
+  "Originality": 3, "Quality": 3, "Clarity": 3, "Significance": 2,
+  "Soundness": 3, "Presentation": 3, "Contribution": 2,
+  "Questions": [...], "Limitations": [...], "Ethical Concerns": false,
+  "Overall": 5, "Confidence": 3, "Decision": "Reject"
+}
+```
+
+Save figure review to `<experiment-dir>/review_img_cap_ref.json`.
+
+## Step 5: Report Results
+
+Present: Decision with score, key strengths, key weaknesses, figure assessment, and improvement recommendations.

--- a/plugin/skills/writeup/SKILL.md
+++ b/plugin/skills/writeup/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: writeup
+description: Generate a scientific paper from completed AI Scientist v2 experiments — uses Claude Code directly with Semantic Scholar for citations
+disable-model-invocation: true
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
+argument-hint: <experiment-dir> [--writeup-type normal|icbinb]
+---
+
+# AI Scientist v2 — Paper Writeup (Claude Code Native)
+
+You are a scientific paper writer generating a complete LaTeX manuscript from experiment results. This skill runs within Claude Code using Semantic Scholar for citation gathering.
+
+## Environment
+
+```bash
+echo "AI_SCIENTIST_ROOT: ${AI_SCIENTIST_ROOT:?'ERROR: Set AI_SCIENTIST_ROOT to the AI-Scientist-v2 repo path'}"
+```
+
+## Arguments
+
+- **Positional arg 1** (`$ARGUMENTS` first word): Path to experiment directory (e.g., `experiments/2025-01-01_my_idea_attempt_0`)
+- `--writeup-type TYPE`: `icbinb` (4-page workshop, default) or `normal` (8-page conference)
+
+## Step 1: Load Experiment Data
+
+Read these files from the experiment directory:
+
+1. **Research idea**: `idea.md` or `research_idea.md`
+2. **Idea JSON**: `idea.json`
+3. **Experiment summaries** (in `logs/0-run/`):
+   - `baseline_summary.json`
+   - `research_summary.json`
+   - `ablation_summary.json`
+4. **Figures**: List all `.png` files in `figures/`
+5. **Plot aggregator script**: `auto_plot_aggregator.py` (if exists)
+
+Read all of these files. The experiment summaries are critical — they contain the full results.
+
+## Step 2: Set Up LaTeX Workspace
+
+```bash
+cd <experiment-dir>
+
+# Choose template based on writeup type
+if [ "$WRITEUP_TYPE" = "normal" ]; then
+  cp -r ${AI_SCIENTIST_ROOT}/ai_scientist/blank_icml_latex latex
+else
+  cp -r ${AI_SCIENTIST_ROOT}/ai_scientist/blank_icbinb_latex latex
+fi
+```
+
+Read the template file at `<experiment-dir>/latex/template.tex`.
+
+## Step 3: Gather Citations
+
+Use **Semantic Scholar** to find relevant papers for citation:
+
+```bash
+cd ${AI_SCIENTIST_ROOT}
+python -c "
+from ai_scientist.tools.semantic_scholar import search_for_papers
+import json
+
+papers = search_for_papers('YOUR SEARCH QUERY', result_limit=5)
+if papers:
+    for p in papers:
+        authors = ', '.join([a.get('name','') for a in p.get('authors',[])])
+        print(f\"Title: {p.get('title')}\")
+        print(f\"Authors: {authors}\")
+        print(f\"Venue: {p.get('venue')}, Year: {p.get('year')}\")
+        print(f\"Citations: {p.get('citationCount')}\")
+        cite = p.get('citationStyles', {}).get('bibtex', '')
+        if cite:
+            print(f'BibTeX: {cite}')
+        print('---')
+"
+```
+
+Perform at least 5-8 separate searches covering different aspects (method, baselines, datasets, related work, etc.) to gather 10-15+ citations.
+
+For each paper found:
+1. Use the BibTeX from Semantic Scholar's `citationStyles.bibtex` field if available
+2. Otherwise, create a BibTeX entry manually
+3. Clean citation keys: lowercase, no accents/special chars, format `authorYYYYkeyword`
+4. Add all citations to the `references.bib` filecontents block in `template.tex`
+
+If Semantic Scholar is unavailable, fall back to **WebSearch**.
+
+## Step 4: Generate Paper Content
+
+Replace the placeholder markers (`%%%%%%%%%SECTION%%%%%%%%%`) in `template.tex` with real content.
+
+### For ICBINB (4-page, single-column):
+- **Title** and **Abstract** (from the idea)
+- **Introduction**: Motivate the research question, state contributions
+- **Related Work**: Position against existing literature (use citations from Step 3)
+- **Background**: Necessary technical background
+- **Method**: Describe the approach in detail
+- **Experimental Setup**: Datasets, metrics, baselines, hyperparameters
+- **Experiments**: Present results with figures and tables. Reference ALL relevant figures
+- **Conclusion**: Summarize findings, limitations, future work
+- **Appendix**: Additional results, ablations, extra figures
+
+### For Normal (8-page, double-column):
+Same sections plus **Impact Statement**.
+
+### Writing Guidelines:
+1. **Figures**: Use `\includegraphics{filename.png}` (template sets `\graphicspath{{../figures/}}`)
+2. **Page limits**: 4 pages for ICBINB, 8 pages for normal, excluding references/appendix
+3. **Accuracy**: Only report results from experiment summaries. Never hallucinate metrics.
+4. **All results**: Include ALL results truthfully — negative results are valuable
+5. **Figures in main text**: For ICBINB, max 4 in main text; rest in appendix
+6. **Citations**: Use `\citep{}` for parenthetical and `\citet{}` for textual
+
+## Step 5: Write the LaTeX File
+
+Use the Edit tool to replace template content section by section.
+
+## Step 6: Compile the Paper
+
+```bash
+cd <experiment-dir>/latex
+pdflatex -interaction=nonstopmode template.tex
+bibtex template
+pdflatex -interaction=nonstopmode template.tex
+pdflatex -interaction=nonstopmode template.tex
+```
+
+## Step 7: Review & Fix Compilation
+
+Check for errors, run `chktex template.tex`, fix issues, recompile (up to 3 attempts).
+
+## Step 8: Finalize
+
+```bash
+cd <experiment-dir>
+FOLDER_NAME=$(basename $(pwd))
+cp latex/template.pdf "${FOLDER_NAME}.pdf"
+```
+
+Report: PDF path, page count, warnings, and suggest `/ai-scientist:review <experiment-dir>`.

--- a/plugin/skills/writeup/SKILL.md
+++ b/plugin/skills/writeup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: writeup
 description: Generate a scientific paper from completed AI Scientist v2 experiments — uses Claude Code directly with Semantic Scholar for citations
-disable-model-invocation: true
+disable-model-invocation: false
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebSearch, WebFetch
 argument-hint: <experiment-dir> [--writeup-type normal|icbinb]
 ---

--- a/plugin/skills/writeup/SKILL.md
+++ b/plugin/skills/writeup/SKILL.md
@@ -12,9 +12,7 @@ You are a scientific paper writer generating a complete LaTeX manuscript from ex
 
 ## Environment
 
-```bash
-echo "AI_SCIENTIST_ROOT: ${AI_SCIENTIST_ROOT:?'ERROR: Set AI_SCIENTIST_ROOT to the AI-Scientist-v2 repo path'}"
-```
+- **PROJECT_DIR**: `${user_config.PROJECT_DIR}` — path to the AI-Scientist-v2 repository.
 
 ## Arguments
 
@@ -43,9 +41,9 @@ cd <experiment-dir>
 
 # Choose template based on writeup type
 if [ "$WRITEUP_TYPE" = "normal" ]; then
-  cp -r ${AI_SCIENTIST_ROOT}/ai_scientist/blank_icml_latex latex
+  cp -r ${user_config.PROJECT_DIR}/ai_scientist/blank_icml_latex latex
 else
-  cp -r ${AI_SCIENTIST_ROOT}/ai_scientist/blank_icbinb_latex latex
+  cp -r ${user_config.PROJECT_DIR}/ai_scientist/blank_icbinb_latex latex
 fi
 ```
 
@@ -56,8 +54,8 @@ Read the template file at `<experiment-dir>/latex/template.tex`.
 Use **Semantic Scholar** to find relevant papers for citation:
 
 ```bash
-cd ${AI_SCIENTIST_ROOT}
-python -c "
+cd ${user_config.PROJECT_DIR}
+S2_API_KEY="${user_config.S2_API_KEY}" python -c "
 from ai_scientist.tools.semantic_scholar import search_for_papers
 import json
 


### PR DESCRIPTION
Convert the AI Scientist v2 research pipeline into 5 Claude Code skills (slash commands) that can be used within Claude Code or Claude Co-Work:

- /ai-scientist: Full end-to-end pipeline
- /ai-scientist-ideate: Research idea generation
- /ai-scientist-experiment: BFTS experiment execution
- /ai-scientist-writeup: Paper generation from results
- /ai-scientist-review: AI peer review of papers

Also adds CLAUDE.md with project context and skill usage documentation.

https://claude.ai/code/session_01NDGeLAQMLY7zFAg2yvYE9R